### PR TITLE
feat: add measurable composable

### DIFF
--- a/src/composables/useMeasurable.js
+++ b/src/composables/useMeasurable.js
@@ -1,0 +1,36 @@
+import { computed } from 'vue'
+import { convertToUnit } from '../../packages/vuetify/src/util/helpers'
+
+export const measurableProps = {
+  height: [Number, String],
+  maxHeight: [Number, String],
+  maxWidth: [Number, String],
+  minHeight: [Number, String],
+  minWidth: [Number, String],
+  width: [Number, String]
+}
+
+export default function useMeasurable (props) {
+  const measurableStyles = computed(() => {
+    const styles = {}
+
+    const height = convertToUnit(props.height)
+    const minHeight = convertToUnit(props.minHeight)
+    const minWidth = convertToUnit(props.minWidth)
+    const maxHeight = convertToUnit(props.maxHeight)
+    const maxWidth = convertToUnit(props.maxWidth)
+    const width = convertToUnit(props.width)
+
+    if (height) styles.height = height
+    if (minHeight) styles.minHeight = minHeight
+    if (minWidth) styles.minWidth = minWidth
+    if (maxHeight) styles.maxHeight = maxHeight
+    if (maxWidth) styles.maxWidth = maxWidth
+    if (width) styles.width = width
+
+    return styles
+  })
+
+  return { measurableStyles }
+}
+


### PR DESCRIPTION
## Summary
- port measurable mixin to a `useMeasurable` composable

## Testing
- `git commit -m "feat: add measurable composable"` *(fails: ReferenceError: __spreadArrays is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a88566fc8327b75460d76a7253c0