### PR TITLE
feat: add groupable composable

### DIFF
--- a/src/composables/useGroupable.js
+++ b/src/composables/useGroupable.js
@@ -1,0 +1,58 @@
+import { inject, ref, computed, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
+
+function registrableInject (namespace, child, parent) {
+  const defaultImpl = child && parent ? {
+    register: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`),
+    unregister: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`)
+  } : null
+
+  return inject(namespace, defaultImpl)
+}
+
+export function factory (namespace, child, parent) {
+  return function useGroupable (props, emit) {
+    const group = registrableInject(namespace, child, parent)
+    const vm = getCurrentInstance()
+
+    const isActive = ref(false)
+
+    const activeClass = computed(() => {
+      if (props.activeClass !== undefined) return props.activeClass
+      return group && group.activeClass
+    })
+
+    const groupClasses = computed(() => {
+      const cls = activeClass.value
+      if (!cls) return {}
+      return { [cls]: isActive.value }
+    })
+
+    onMounted(() => {
+      if (group && group.register && vm) {
+        group.register(vm.proxy)
+      }
+    })
+
+    onBeforeUnmount(() => {
+      if (group && group.unregister && vm) {
+        group.unregister(vm.proxy)
+      }
+    })
+
+    function toggle () {
+      emit && emit('change')
+    }
+
+    return {
+      isActive,
+      activeClass,
+      groupClasses,
+      toggle
+    }
+  }
+}
+
+const useGroupable = factory('itemGroup')
+
+export default useGroupable
+


### PR DESCRIPTION
## Summary
- port groupable mixin factory to Composition API in `useGroupable`
- expose isActive state, toggle method, and computed group classes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a87ffbe883278b4b4992eced7ce5