### PR TITLE
feat: add useFilterable composable

### DIFF
--- a/src/composables/useFilterable.js
+++ b/src/composables/useFilterable.js
@@ -1,0 +1,16 @@
+import { toRef } from 'vue'
+
+export const filterableProps = {
+  noDataText: {
+    type: String,
+    default: '$vuetify.noDataText'
+  }
+}
+
+export default function useFilterable (props) {
+  const noDataText = toRef(props, 'noDataText')
+
+  return {
+    noDataText
+  }
+}


### PR DESCRIPTION
## Summary
- migrate filterable mixin to useFilterable composable
- expose noDataText prop via composable return

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint src/composables/useFilterable.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6a87f14208327bcc7db7ff76ac013