### PR TITLE
feat: add useElevatable composable

### DIFF
--- a/src/composables/useElevatable.js
+++ b/src/composables/useElevatable.js
@@ -1,0 +1,17 @@
+import { computed } from 'vue'
+
+export default function useElevatable (props) {
+  const computedElevation = computed(() => props.elevation)
+
+  const elevationClasses = computed(() => {
+    const elevation = computedElevation.value
+    if (!elevation && elevation !== 0) return {}
+    return { [`elevation-${elevation}`]: true }
+  })
+
+  return {
+    computedElevation,
+    elevationClasses,
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `useElevatable` composable mirroring the old `elevatable` mixin
- expose `computedElevation` and `elevationClasses` helpers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a87caa248327adeb163706c8dca7