### PR TITLE
feat: add useDependent composable

### DIFF
--- a/src/composables/useDependent.js
+++ b/src/composables/useDependent.js
@@ -1,0 +1,72 @@
+import { getCurrentInstance, ref, watch } from 'vue'
+
+function searchChildren (children) {
+  const results = []
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index]
+
+    if (child.isActive && child.isDependent) {
+      results.push(child)
+    } else if (child.$children) {
+      results.push(...searchChildren(child.$children))
+    }
+  }
+
+  return results
+}
+
+export default function useDependent () {
+  const { proxy } = getCurrentInstance()
+
+  const closeDependents = ref(true)
+  const isActive = ref(false)
+  const isDependent = ref(true)
+
+  function getOpenDependents () {
+    if (closeDependents.value) return searchChildren(proxy.$children || [])
+
+    return []
+  }
+
+  function getOpenDependentElements () {
+    const result = []
+    const openDependents = getOpenDependents()
+
+    for (let index = 0; index < openDependents.length; index++) {
+      result.push(...openDependents[index].getClickableDependentElements())
+    }
+
+    return result
+  }
+
+  function getClickableDependentElements () {
+    const result = [proxy.$el]
+
+    const content = proxy.$refs && proxy.$refs.content
+    if (content) result.push(content)
+    if (proxy.overlay) result.push(proxy.overlay)
+
+    result.push(...getOpenDependentElements())
+
+    return result
+  }
+
+  watch(isActive, val => {
+    if (val) return
+
+    const openDependents = getOpenDependents()
+    for (let index = 0; index < openDependents.length; index++) {
+      openDependents[index].isActive = false
+    }
+  })
+
+  return {
+    closeDependents,
+    isActive,
+    isDependent,
+    getOpenDependents,
+    getOpenDependentElements,
+    getClickableDependentElements
+  }
+}


### PR DESCRIPTION
## Summary
- port dependent mixin to Composition API
- expose reactive dependent state and helper functions

## Testing
- `npx eslint src/composables/useDependent.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a87a316c8327b457e36473164e62