### PR TITLE
feat: add comparable composable

### DIFF
--- a/src/composables/useComparable.js
+++ b/src/composables/useComparable.js
@@ -1,0 +1,14 @@
+import { deepEqual } from '../../packages/vuetify/src/util/helpers'
+
+export const comparableProps = {
+  valueComparator: {
+    type: Function,
+    default: deepEqual,
+  },
+}
+
+export default function useComparable (props) {
+  const valueComparator = props.valueComparator || deepEqual
+
+  return { valueComparator }
+}


### PR DESCRIPTION
## Summary
- migrate comparable mixin to new useComparable composable
- allow custom valueComparator with deepEqual default
- return comparator for arbitrary value checks

## Testing
- `node --check src/composables/useComparable.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6a8759a448327a83f64b8d52ee7ae