### PR TITLE
feat: add button group composable

### DIFF
--- a/src/composables/useButtonGroup.js
+++ b/src/composables/useButtonGroup.js
@@ -1,0 +1,35 @@
+import { computed, provide, reactive } from 'vue'
+
+export default function useButtonGroup (props = {}) {
+  const state = reactive({
+    items: []
+  })
+
+  function register (item) {
+    state.items.push(item)
+  }
+
+  function unregister (item) {
+    const index = state.items.indexOf(item)
+    if (index !== -1) state.items.splice(index, 1)
+  }
+
+  const activeClass = computed(() => props.activeClass || 'v-btn--active')
+
+  const classes = computed(() => ({ }))
+
+  const btnToggle = {
+    register,
+    unregister,
+    activeClass: activeClass.value
+  }
+
+  provide('btnToggle', btnToggle)
+
+  return {
+    register,
+    unregister,
+    activeClass,
+    classes
+  }
+}


### PR DESCRIPTION
## Summary
- add `useButtonGroup` composable for button group logic

## Testing
- `git commit -m "feat: add button group composable"` *(fails: ReferenceError: __spreadArrays is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8735b788327a0ca40c83a158350