### PR TITLE
feat: add bootable composable

### DIFF
--- a/src/composables/useBootable.js
+++ b/src/composables/useBootable.js
@@ -1,0 +1,26 @@
+import { ref, computed, watch } from 'vue'
+
+export default function useBootable (props, opts = {}) {
+  const isBooted = ref(false)
+
+  const hasContent = computed(() => {
+    return isBooted.value || !props.lazy || (opts.isActive && opts.isActive.value)
+  })
+
+  if (opts.isActive) {
+    watch(opts.isActive, () => {
+      isBooted.value = true
+    })
+  }
+
+  function showLazyContent (content) {
+    return hasContent.value ? content : undefined
+  }
+
+  return {
+    isBooted,
+    hasContent,
+    showLazyContent,
+  }
+}
+


### PR DESCRIPTION
## Summary
- port bootable mixin to a Composition API composable
- expose `isBooted`, computed `hasContent`, and `showLazyContent` helper

## Testing
- `yarn test src/composables/useBootable.js --passWithNoTests` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8723cfc83278df034b334ca8eee