### PR TITLE
feat: add toggleable composable

### DIFF
--- a/src/composables/useToggleable.js
+++ b/src/composables/useToggleable.js
@@ -1,0 +1,20 @@
+import { ref, watch } from 'vue'
+
+export function factory (prop = 'value', event = 'input') {
+  return function useToggleable (props, emit) {
+    const isActive = ref(!!props[prop])
+
+    watch(() => props[prop], val => { isActive.value = !!val })
+
+    watch(isActive, val => {
+      !!val !== props[prop] && emit && emit(event, val)
+    })
+
+    return { isActive }
+  }
+}
+
+const useToggleable = factory()
+
+export default useToggleable
+


### PR DESCRIPTION
## Summary
- convert toggleable mixin to useToggleable composable
- sync isActive state with external prop and emit changes
- allow custom prop and event names via factory

## Testing
- `npm test packages/vuetify/test/unit/mixins/dependent.spec.js` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7e95614a883279f130a99be02bae8