### PR TITLE
feat: add stackable composable

### DIFF
--- a/src/composables/useStackable.js
+++ b/src/composables/useStackable.js
@@ -1,0 +1,49 @@
+import { computed, getCurrentInstance, ref } from 'vue'
+import { getZIndex } from '../../packages/vuetify/src/util/helpers'
+
+export default function useStackable () {
+  const { proxy } = getCurrentInstance()
+
+  const stackClass = ref('unpecified')
+  const stackElement = ref(null)
+  const stackExclude = ref(null)
+  const stackMinZIndex = ref(0)
+  const isActive = ref(false)
+
+  function getMaxZIndex (exclude = []) {
+    const base = proxy.$el
+    const zis = [stackMinZIndex.value, getZIndex(base)]
+    const activeElements = [...document.getElementsByClassName(stackClass.value)]
+
+    for (let index = 0; index < activeElements.length; index++) {
+      if (!exclude.includes(activeElements[index])) {
+        zis.push(getZIndex(activeElements[index]))
+      }
+    }
+
+    return Math.max(...zis)
+  }
+
+  const activeZIndex = computed(() => {
+    if (typeof window === 'undefined') return 0
+
+    const content = stackElement.value || (proxy.$refs && proxy.$refs.content)
+    const index = !isActive.value
+      ? getZIndex(content)
+      : getMaxZIndex(stackExclude.value || [content]) + 2
+
+    if (index == null) return index
+
+    return parseInt(index)
+  })
+
+  return {
+    stackClass,
+    stackElement,
+    stackExclude,
+    stackMinZIndex,
+    isActive,
+    getMaxZIndex,
+    activeZIndex
+  }
+}


### PR DESCRIPTION
## Summary
- port stackable mixin to `useStackable` composable
- compute activeZIndex with a helper to get the max z-index among active elements

## Testing
- `npx eslint src/composables/useStackable.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7e953e26883279d3bb08a7da82a9b