### PR TITLE
feat: add useSizeable composable

### DIFF
--- a/src/composables/useSizeable.js
+++ b/src/composables/useSizeable.js
@@ -1,0 +1,16 @@
+import { toRefs } from 'vue'
+
+export const sizeableProps = {
+  large: Boolean,
+  medium: Boolean,
+  size: [Number, String],
+  small: Boolean,
+  xLarge: Boolean,
+}
+
+export default function useSizeable (props) {
+  const { large, medium, size, small, xLarge } = toRefs(props)
+
+  return { large, medium, size, small, xLarge }
+}
+


### PR DESCRIPTION
## Summary
- add useSizeable composable exposing size props for components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: root-workspace package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e951dc548327bbb55bfb9c3b2f83