### PR TITLE
feat: add rippleable composable

### DIFF
--- a/src/composables/useRippleable.js
+++ b/src/composables/useRippleable.js
@@ -1,0 +1,35 @@
+import { h, withDirectives } from 'vue'
+import Ripple from '../../packages/vuetify/src/directives/ripple'
+
+export const rippleableProps = {
+  ripple: {
+    type: [Boolean, Object],
+    default: true,
+  },
+}
+
+export default function useRippleable (props, { onChange = () => {} } = {}) {
+  function genRipple (data = {}) {
+    if (!props.ripple) return null
+
+    const {
+      class: className,
+      directives = [],
+      ...rest
+    } = data
+
+    const node = h('div', {
+      ...rest,
+      class: ['v-input--selection-controls__ripple', className],
+      onClick: onChange,
+    })
+
+    return withDirectives(node, [
+      ...directives,
+      [Ripple, typeof props.ripple === 'object' ? props.ripple : { center: true }],
+    ])
+  }
+
+  return { genRipple }
+}
+


### PR DESCRIPTION
## Summary
- add useRippleable composable to replace rippleable mixin
- allow custom onChange and ripple options in genRipple

## Testing
- `node -c src/composables/useRippleable.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7e94b30048327868bd0bbb32fdad4