### PR TITLE
feat: add registrable composables

### DIFF
--- a/src/composables/useGroupable.js
+++ b/src/composables/useGroupable.js
@@ -1,17 +1,9 @@
-import { inject, ref, computed, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
-
-function registrableInject (namespace, child, parent) {
-  const defaultImpl = child && parent ? {
-    register: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`),
-    unregister: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`)
-  } : null
-
-  return inject(namespace, defaultImpl)
-}
+import { ref, computed, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
+import useRegistrableInject from './useRegistrableInject'
 
 export function factory (namespace, child, parent) {
   return function useGroupable (props, emit) {
-    const group = registrableInject(namespace, child, parent)
+    const group = useRegistrableInject(namespace, child, parent)
     const vm = getCurrentInstance()
 
     const isActive = ref(false)

--- a/src/composables/useRegistrableInject.js
+++ b/src/composables/useRegistrableInject.js
@@ -1,0 +1,11 @@
+import { inject } from 'vue'
+
+export default function useRegistrableInject (namespace, child, parent) {
+  const defaultImpl = child && parent ? {
+    register: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`),
+    unregister: () => console.warn(`[Vuetify] The ${child} component must be used inside a ${parent}`)
+  } : null
+
+  return inject(namespace, defaultImpl)
+}
+

--- a/src/composables/useRegistrableProvide.js
+++ b/src/composables/useRegistrableProvide.js
@@ -1,0 +1,20 @@
+import { provide } from 'vue'
+
+export default function useRegistrableProvide (namespace) {
+  const children = []
+
+  function register (child) {
+    const index = children.indexOf(child)
+    if (index < 0) children.push(child)
+  }
+
+  function unregister (child) {
+    const index = children.indexOf(child)
+    if (index !== -1) children.splice(index, 1)
+  }
+
+  provide(namespace, { register, unregister })
+
+  return { children, register, unregister }
+}
+


### PR DESCRIPTION
## Summary
- add registrable provide/inject composables for parent-child registration
- refactor useGroupable to use new registrable inject helper

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7e948b298832791542566a2f0a13b