### PR TITLE
feat: add usePicker composable

### DIFF
--- a/src/composables/usePicker.js
+++ b/src/composables/usePicker.js
@@ -1,0 +1,59 @@
+import { h } from 'vue'
+import VPicker from '../components/VPicker'
+
+export const pickerProps = {
+  fullWidth: Boolean,
+  headerColor: String,
+  landscape: Boolean,
+  noTitle: Boolean,
+  width: {
+    type: [Number, String],
+    default: 290
+  }
+}
+
+export default function usePicker (props, { slots, save, cancel } = {}) {
+  function genPickerTitle () {
+    return null
+  }
+
+  function genPickerBody () {
+    return null
+  }
+
+  function genPickerActionsSlot () {
+    return slots && slots.default ? slots.default({ save, cancel }) : undefined
+  }
+
+  function genPicker (staticClass) {
+    const pickerSlots = {}
+
+    if (!props.noTitle) {
+      const title = genPickerTitle()
+      if (title) pickerSlots.title = () => title
+    }
+
+    const body = genPickerBody()
+    if (body) pickerSlots.default = () => body
+
+    const actions = genPickerActionsSlot()
+    if (actions) pickerSlots.actions = () => actions
+
+    return h(VPicker, {
+      class: staticClass,
+      color: props.headerColor || props.color,
+      dark: props.dark,
+      fullWidth: props.fullWidth,
+      landscape: props.landscape,
+      light: props.light,
+      width: props.width
+    }, pickerSlots)
+  }
+
+  return {
+    genPickerTitle,
+    genPickerBody,
+    genPickerActionsSlot,
+    genPicker
+  }
+}


### PR DESCRIPTION
## Summary
- translate picker mixin into usePicker composable for Vue 3
- expose props and generator methods for building pickers with VPicker

## Testing
- `npx eslint src/composables/usePicker.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7e9463ca08327b8796533d0f9eb9b