### PR TITLE
feat: add picker button composable

### DIFF
--- a/src/composables/usePickerButton.js
+++ b/src/composables/usePickerButton.js
@@ -1,0 +1,36 @@
+import { h } from 'vue'
+import useColorable, { colorProps } from './useColorable'
+
+export const pickerButtonProps = {
+  ...colorProps
+}
+
+export default function usePickerButton (props, { emit }) {
+  const { setTextColor } = useColorable(props)
+
+  function genPickerButton (prop, value, content, readonly = false, staticClass = '') {
+    const active = props[prop] === value
+
+    const data = setTextColor(active ? props.color : undefined, {
+      class: {
+        'v-picker__title__btn--active': active,
+        'v-picker__title__btn--readonly': readonly
+      }
+    })
+
+    return h('div', {
+      class: [
+        'v-picker__title__btn',
+        staticClass,
+        data.class
+      ],
+      style: data.style,
+      onClick: (active || readonly) ? undefined : (event) => {
+        event.stopPropagation()
+        emit(`update:${prop}`, value)
+      }
+    }, Array.isArray(content) ? content : [content])
+  }
+
+  return { genPickerButton }
+}


### PR DESCRIPTION
## Summary
- add `usePickerButton` composable for picker title buttons
- support colorable styling and update events

## Testing
- `npm test packages/vuetify/test/unit/mixins/colorable.spec.js` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7e945ccd8832781346c7a04f66ee3