### PR TITLE
refactor: migrate simple components to composables

### DIFF
--- a/src/components/VAvatar/VAvatar.ts
+++ b/src/components/VAvatar/VAvatar.ts
@@ -1,23 +1,19 @@
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import Colorable from '../../mixins/colorable'
+// Composables
+import useColorable, { colorProps } from '../../composables/useColorable'
+
+// Utilities
 import { convertToUnit } from '../../util/helpers'
 
 // Types
-import { VNode } from 'vue'
-import mixins from '../../util/mixins'
+import { defineComponent, h } from 'vue'
 
-/* @vue/component */
-export default mixins(Colorable).extend({
+export default defineComponent({
   name: 'v-avatar',
 
-  functional: true,
-
   props: {
-    // TODO: inherit these
-    color: String,
-
+    ...colorProps,
     size: {
       type: [Number, String],
       default: 48
@@ -25,18 +21,20 @@ export default mixins(Colorable).extend({
     tile: Boolean
   },
 
-  render (h, { data, props, children }): VNode {
-    data.staticClass = (`v-avatar ${data.staticClass || ''}`).trim()
+  setup (props, { slots }) {
+    const { setBackgroundColor } = useColorable(props)
 
-    if (props.tile) data.staticClass += ' v-avatar--tile'
+    return () => {
+      const size = convertToUnit(props.size)
+      const data = {
+        class: ['v-avatar', { 'v-avatar--tile': props.tile }],
+        style: {
+          height: size,
+          width: size
+        }
+      }
 
-    const size = convertToUnit(props.size)
-    data.style = {
-      height: size,
-      width: size,
-      ...data.style as object
+      return h('div', setBackgroundColor(props.color, data), slots.default?.())
     }
-
-    return h('div', Colorable.options.methods.setBackgroundColor(props.color, data), children)
   }
 })

--- a/src/components/VCounter/VCounter.ts
+++ b/src/components/VCounter/VCounter.ts
@@ -1,20 +1,17 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import Themeable, { functionalThemeClasses } from '../../mixins/themeable'
+// Composables
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Types
-import { VNode } from 'vue'
-import mixins from '../../util/mixins'
+import { defineComponent, h } from 'vue'
 
-/* @vue/component */
-export default mixins(Themeable).extend({
+export default defineComponent({
   name: 'v-counter',
 
-  functional: true,
-
   props: {
+    ...themeProps,
     value: {
       type: [Number, String],
       default: ''
@@ -22,19 +19,18 @@ export default mixins(Themeable).extend({
     max: [Number, String]
   },
 
-  render (h, ctx): VNode {
-    const { props } = ctx
-    const max = parseInt(props.max, 10)
-    const value = parseInt(props.value, 10)
-    const content = max ? `${value} / ${max}` : String(props.value)
-    const isGreater = max && (value > max)
+  setup (props) {
+    const { themeClasses } = useThemeable(props)
 
-    return h('div', {
-      staticClass: 'v-counter',
-      class: {
-        'error--text': isGreater,
-        ...functionalThemeClasses(ctx)
-      }
-    }, content)
+    return () => {
+      const max = parseInt(props.max as any, 10)
+      const value = parseInt(props.value as any, 10)
+      const content = max ? `${value} / ${max}` : String(props.value)
+      const isGreater = max && (value > max)
+
+      return h('div', {
+        class: ['v-counter', { 'error--text': isGreater }, themeClasses.value]
+      }, content)
+    }
   }
 })

--- a/src/components/VLabel/VLabel.ts
+++ b/src/components/VLabel/VLabel.ts
@@ -1,24 +1,21 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import Colorable from '../../mixins/colorable'
-import Themeable, { functionalThemeClasses } from '../../mixins/themeable'
+// Composables
+import useColorable from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
-// Types
-import { VNode } from 'vue'
-import mixins from '../../util/mixins'
-
-// Helpers
+// Utilities
 import { convertToUnit } from '../../util/helpers'
 
-/* @vue/component */
-export default mixins(Themeable).extend({
+// Types
+import { defineComponent, h } from 'vue'
+
+export default defineComponent({
   name: 'v-label',
 
-  functional: true,
-
   props: {
+    ...themeProps,
     absolute: Boolean,
     color: {
       type: String,
@@ -38,27 +35,28 @@ export default mixins(Themeable).extend({
     value: Boolean
   },
 
-  render (h, ctx): VNode {
-    const { children, listeners, props } = ctx
-    const data = {
-      staticClass: 'v-label',
-      'class': {
-        'v-label--active': props.value,
-        'v-label--is-disabled': props.disabled,
-        ...functionalThemeClasses(ctx)
-      },
-      attrs: {
-        for: props.for,
-        'aria-hidden': !props.for
-      },
-      on: listeners,
-      style: {
-        left: convertToUnit(props.left),
-        right: convertToUnit(props.right),
-        position: props.absolute ? 'absolute' : 'relative'
-      }
-    }
+  setup (props, { slots, attrs }) {
+    const { setTextColor } = useColorable(props)
+    const { themeClasses } = useThemeable(props)
 
-    return h('label', Colorable.options.methods.setTextColor(props.focused && props.color, data), children)
+    return () => {
+      const data = {
+        class: ['v-label', {
+          'v-label--active': props.value,
+          'v-label--is-disabled': props.disabled,
+          ...themeClasses.value
+        }],
+        style: {
+          left: convertToUnit(props.left),
+          right: convertToUnit(props.right),
+          position: props.absolute ? 'absolute' : 'relative'
+        },
+        for: props.for,
+        'aria-hidden': !props.for,
+        ...attrs
+      }
+
+      return h('label', setTextColor(props.focused && props.color, data), slots.default?.())
+    }
   }
 })

--- a/src/components/VSubheader/VSubheader.ts
+++ b/src/components/VSubheader/VSubheader.ts
@@ -1,32 +1,26 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import Themeable from '../../mixins/themeable'
-import mixins from '../../util/mixins'
+// Composables
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Types
-import { VNode } from 'vue'
+import { defineComponent, h } from 'vue'
 
-export default mixins(
-  Themeable
-  /* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-subheader',
 
   props: {
+    ...themeProps,
     inset: Boolean
   },
 
-  render (h): VNode {
-    return h('div', {
-      staticClass: 'v-subheader',
-      class: {
-        'v-subheader--inset': this.inset,
-        ...this.themeClasses
-      },
-      attrs: this.$attrs,
-      on: this.$listeners
-    }, this.$slots.default)
+  setup (props, { attrs, slots }) {
+    const { themeClasses } = useThemeable(props)
+
+    return () => h('div', {
+      class: ['v-subheader', { 'v-subheader--inset': props.inset }, themeClasses.value],
+      ...attrs
+    }, slots.default?.())
   }
 })


### PR DESCRIPTION
## Summary
- refactor VAvatar to Composition API using useColorable
- migrate VCounter, VLabel, and VSubheader from mixins to composables

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install")*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install")*

------
https://chatgpt.com/codex/tasks/task_e_68c828ce1834832793a952ce8f8331ce