### PR TITLE
refactor: migrate alert and subheader to composition API

### DIFF
--- a/src/components/VAlert/VAlert.ts
+++ b/src/components/VAlert/VAlert.ts
@@ -4,17 +4,15 @@ import "@/css/vuetify.css"
 // Components
 import VIcon from '../VIcon'
 
-// Mixins
-import Colorable from '../../mixins/colorable'
-import Toggleable from '../../mixins/toggleable'
-import Transitionable from '../../mixins/transitionable'
+// Composables
+import useColorable, { colorProps } from '../../composables/useColorable'
+import useToggleable from '../../composables/useToggleable'
+import useTransitionable, { transitionableProps } from '../../composables/useTransitionable'
 
-// Types
-import { VNode } from 'vue/types'
-import mixins from '../../util/mixins'
+// Utilities
+import { defineComponent, computed, h, withDirectives, vShow, Transition } from 'vue'
 
-/* @vue/component */
-export default mixins(Colorable, Toggleable, Transitionable).extend({
+export default defineComponent({
   name: 'v-alert',
 
   props: {
@@ -31,77 +29,79 @@ export default mixins(Colorable, Toggleable, Transitionable).extend({
           'warning'
         ].includes(val)
       }
-    }
+    },
+    value: null,
+    ...colorProps,
+    ...transitionableProps
   },
 
-  computed: {
-    computedColor (): string {
-      return (this.type && !this.color) ? this.type : (this.color || 'error')
-    },
-    computedIcon (): string | void {
-      if (this.icon || !this.type) return this.icon
+  emits: ['input'],
 
-      switch (this.type) {
+  setup (props, { slots, emit }) {
+    const { setBackgroundColor, setTextColor } = useColorable(props)
+    const { isActive } = useToggleable(props, emit)
+    const { mode, origin, transition } = useTransitionable(props)
+
+    const computedColor = computed(() => (props.type && !props.color) ? props.type : (props.color || 'error'))
+    const computedIcon = computed(() => {
+      if (props.icon || !props.type) return props.icon
+
+      switch (props.type) {
         case 'info': return '$vuetify.icons.info'
         case 'error': return '$vuetify.icons.error'
         case 'success': return '$vuetify.icons.success'
         case 'warning': return '$vuetify.icons.warning'
       }
+    })
+
+    function genIcon () {
+      if (!computedIcon.value) return null
+      return h(VIcon, { class: 'v-alert__icon' }, { default: () => computedIcon.value })
+    }
+
+    function genDismissible () {
+      if (!props.dismissible) return null
+      return h('a', {
+        class: 'v-alert__dismissible',
+        onClick: () => { isActive.value = false }
+      }, [h(VIcon, { right: true }, { default: () => '$vuetify.icons.cancel' })])
+    }
+
+    return {
+      computedColor,
+      genDismissible,
+      genIcon,
+      isActive,
+      mode,
+      origin,
+      setBackgroundColor,
+      setTextColor,
+      transition,
+      slots
     }
   },
 
-  methods: {
-    genIcon (): VNode | null {
-      if (!this.computedIcon) return null
-
-      return this.$createElement(VIcon, {
-        'class': 'v-alert__icon'
-      }, this.computedIcon)
-    },
-
-    genDismissible (): VNode | null {
-      if (!this.dismissible) return null
-
-      return this.$createElement('a', {
-        'class': 'v-alert__dismissible',
-        on: { click: () => { this.isActive = false } }
-      }, [
-        this.$createElement(VIcon, {
-          props: {
-            right: true
-          }
-        }, '$vuetify.icons.cancel')
-      ])
-    }
-  },
-
-  render (h): VNode {
+  render () {
     const children = [
       this.genIcon(),
-      h('div', this.$slots.default),
+      h('div', this.$slots.default && this.$slots.default()),
       this.genDismissible()
-    ] as any
+    ]
     const setColor = this.outline ? this.setTextColor : this.setBackgroundColor
-    const alert = h('div', setColor(this.computedColor, {
-      staticClass: 'v-alert',
-      'class': {
+    const alert = withDirectives(h('div', setColor(this.computedColor, {
+      class: {
+        'v-alert': true,
         'v-alert--outline': this.outline
       },
-      directives: [{
-        name: 'show',
-        value: this.isActive
-      }],
-      on: this.$listeners
-    }), children)
+      ...this.$attrs
+    }), children), [[vShow, this.isActive]])
 
     if (!this.transition) return alert
 
-    return h('transition', {
-      props: {
-        name: this.transition,
-        origin: this.origin,
-        mode: this.mode
-      }
-    }, [alert])
+    return h(Transition, {
+      name: this.transition,
+      mode: this.mode
+    }, { default: () => [alert] })
   }
 })
+

--- a/src/components/VSubheader/VSubheader.ts
+++ b/src/components/VSubheader/VSubheader.ts
@@ -1,32 +1,29 @@
 // Styles
 import "@/css/vuetify.css"
 
-// Mixins
-import Themeable from '../../mixins/themeable'
-import mixins from '../../util/mixins'
+import { defineComponent, h } from 'vue'
 
-// Types
-import { VNode } from 'vue'
+// Composables
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
-export default mixins(
-  Themeable
-  /* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-subheader',
 
   props: {
-    inset: Boolean
+    inset: Boolean,
+    ...themeProps
   },
 
-  render (h): VNode {
-    return h('div', {
-      staticClass: 'v-subheader',
+  setup (props, { slots, attrs }) {
+    const { themeClasses } = useThemeable(props)
+
+    return () => h('div', {
       class: {
-        'v-subheader--inset': this.inset,
-        ...this.themeClasses
+        'v-subheader': true,
+        'v-subheader--inset': props.inset,
+        ...themeClasses.value
       },
-      attrs: this.$attrs,
-      on: this.$listeners
-    }, this.$slots.default)
+      ...attrs
+    }, slots.default && slots.default())
   }
 })


### PR DESCRIPTION
## Summary
- refactor VAlert to use defineComponent and composition API composables
- refactor VSubheader to composition API with theme support

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c828cf48f083278585819e8782d42c