### PR TITLE
refactor: migrate breadcrumbs and bottom sheet to composition api

### DIFF
--- a/src/components/VBottomSheet/VBottomSheet.js
+++ b/src/components/VBottomSheet/VBottomSheet.js
@@ -1,9 +1,15 @@
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
+// Components
 import VDialog from '../VDialog/VDialog'
 
-/* @vue/component */
-export default {
+// Composables
+import useToggleable from '../../composables/useToggleable'
+
+// Types
+import { defineComponent, h } from 'vue'
+
+export default defineComponent({
   name: 'v-bottom-sheet',
 
   props: {
@@ -20,29 +26,26 @@ export default {
     value: null
   },
 
-  render (h) {
-    const activator = h('template', {
-      slot: 'activator'
-    }, this.$slots.activator)
+  setup (props, { slots, attrs, emit }) {
+    const { isActive } = useToggleable(props, emit)
 
-    const contentClass = [
-      'v-bottom-sheet',
-      this.inset ? 'v-bottom-sheet--inset' : ''
-    ].join(' ')
+    return () => {
+      const contentClass = [
+        'v-bottom-sheet',
+        props.inset ? 'v-bottom-sheet--inset' : ''
+      ].join(' ')
 
-    return h(VDialog, {
-      attrs: {
-        ...this.$props
-      },
-      on: {
-        ...this.$listeners
-      },
-      props: {
+      return h(VDialog, {
+        ...attrs,
+        ...props,
         contentClass,
         noClickAnimation: true,
         transition: 'bottom-sheet-transition',
-        value: this.value
-      }
-    }, [activator, this.$slots.default])
+        value: isActive.value
+      }, {
+        activator: slots.activator,
+        default: slots.default
+      })
+    }
   }
-}
+})

--- a/src/components/VBreadcrumbs/VBreadcrumbsItem.ts
+++ b/src/components/VBreadcrumbs/VBreadcrumbsItem.ts
@@ -1,13 +1,13 @@
-import Routable from '../../mixins/routable'
+import { defineComponent, h, computed } from 'vue'
 
-import mixins from '../../util/mixins'
-import { VNode } from 'vue'
+// Composables
+import useRoutable, { routableProps } from '../../composables/useRoutable'
 
-/* @vue/component */
-export default mixins(Routable).extend({
+export default defineComponent({
   name: 'v-breadcrumbs-item',
 
   props: {
+    ...routableProps,
     // In a breadcrumb, the currently
     // active item should be dimmed
     activeClass: {
@@ -16,20 +16,17 @@ export default mixins(Routable).extend({
     }
   },
 
-  computed: {
-    classes (): object {
-      return {
-        'v-breadcrumbs__item': true,
-        [this.activeClass]: this.disabled
-      }
+  setup (props, { attrs, slots, emit }) {
+    const { generateRouteLink } = useRoutable(props, { attrs, emit })
+
+    const classes = computed(() => ({
+      'v-breadcrumbs__item': true,
+      [props.activeClass]: props.disabled
+    }))
+
+    return () => {
+      const { tag, data } = generateRouteLink(classes.value)
+      return h('li', [h(tag, data, slots.default?.())])
     }
-  },
-
-  render (h): VNode {
-    const { tag, data } = this.generateRouteLink(this.classes)
-
-    return h('li', [
-      h(tag, data, this.$slots.default)
-    ])
   }
 })


### PR DESCRIPTION
## Summary
- migrate VBottomSheet to use defineComponent and useToggleable
- convert VBreadcrumbs and VBreadcrumbsItem to Composition API and composables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c83532206c832789aebc4855b38d2b