### PR TITLE
refactor: migrate components to composition api

### DIFF
--- a/src/components/VAlert/VAlert.ts
+++ b/src/components/VAlert/VAlert.ts
@@ -1,20 +1,18 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
 // Components
 import VIcon from '../VIcon'
 
-// Mixins
-import Colorable from '../../mixins/colorable'
-import Toggleable from '../../mixins/toggleable'
-import Transitionable from '../../mixins/transitionable'
+// Composables
+import useColorable, { colorProps } from '../../composables/useColorable'
+import useToggleable from '../../composables/useToggleable'
+import useTransitionable, { transitionableProps } from '../../composables/useTransitionable'
 
 // Types
-import { VNode } from 'vue/types'
-import mixins from '../../util/mixins'
+import { defineComponent, h, withDirectives, vShow, computed } from 'vue'
 
-/* @vue/component */
-export default mixins(Colorable, Toggleable, Transitionable).extend({
+export default defineComponent({
   name: 'v-alert',
 
   props: {
@@ -31,77 +29,69 @@ export default mixins(Colorable, Toggleable, Transitionable).extend({
           'warning'
         ].includes(val)
       }
-    }
+    },
+    ...colorProps,
+    value: { type: Boolean, default: true },
+    ...transitionableProps
   },
 
-  computed: {
-    computedColor (): string {
-      return (this.type && !this.color) ? this.type : (this.color || 'error')
-    },
-    computedIcon (): string | void {
-      if (this.icon || !this.type) return this.icon
+  setup (props, { slots, emit, attrs }) {
+    const { setBackgroundColor, setTextColor } = useColorable(props)
+    const { isActive } = useToggleable(props, emit)
+    const { transition, origin, mode } = useTransitionable(props)
 
-      switch (this.type) {
+    const computedColor = computed(() => (props.type && !props.color) ? props.type : (props.color || 'error'))
+    const computedIcon = computed(() => {
+      if (props.icon || !props.type) return props.icon
+      switch (props.type) {
         case 'info': return '$vuetify.icons.info'
         case 'error': return '$vuetify.icons.error'
         case 'success': return '$vuetify.icons.success'
         case 'warning': return '$vuetify.icons.warning'
       }
+    })
+
+    function genIcon () {
+      if (!computedIcon.value) return null
+      return h(VIcon, { class: 'v-alert__icon' }, { default: () => computedIcon.value })
     }
-  },
 
-  methods: {
-    genIcon (): VNode | null {
-      if (!this.computedIcon) return null
-
-      return this.$createElement(VIcon, {
-        'class': 'v-alert__icon'
-      }, this.computedIcon)
-    },
-
-    genDismissible (): VNode | null {
-      if (!this.dismissible) return null
-
-      return this.$createElement('a', {
-        'class': 'v-alert__dismissible',
-        on: { click: () => { this.isActive = false } }
+    function genDismissible () {
+      if (!props.dismissible) return null
+      return h('a', {
+        class: 'v-alert__dismissible',
+        onClick: () => { isActive.value = false }
       }, [
-        this.$createElement(VIcon, {
-          props: {
-            right: true
-          }
-        }, '$vuetify.icons.cancel')
+        h(VIcon, { right: true }, { default: () => '$vuetify.icons.cancel' })
       ])
     }
-  },
 
-  render (h): VNode {
-    const children = [
-      this.genIcon(),
-      h('div', this.$slots.default),
-      this.genDismissible()
-    ] as any
-    const setColor = this.outline ? this.setTextColor : this.setBackgroundColor
-    const alert = h('div', setColor(this.computedColor, {
-      staticClass: 'v-alert',
-      'class': {
-        'v-alert--outline': this.outline
-      },
-      directives: [{
-        name: 'show',
-        value: this.isActive
-      }],
-      on: this.$listeners
-    }), children)
+    return () => {
+      const children = [
+        genIcon(),
+        h('div', slots.default?.()),
+        genDismissible()
+      ]
+      const setColor = props.outline ? setTextColor : setBackgroundColor
+      const alert = withDirectives(
+        h('div', setColor(computedColor.value, {
+          class: {
+            'v-alert': true,
+            'v-alert--outline': props.outline
+          },
+          ...attrs
+        }), children),
+        [[vShow, isActive.value]]
+      )
 
-    if (!this.transition) return alert
+      if (!props.transition) return alert
 
-    return h('transition', {
-      props: {
-        name: this.transition,
-        origin: this.origin,
-        mode: this.mode
-      }
-    }, [alert])
+      return h('transition', {
+        name: transition.value,
+        origin: origin.value,
+        mode: mode.value
+      }, { default: () => [alert] })
+    }
   }
 })
+

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -1,5 +1,5 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
 // Extensions
 import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelect'
@@ -8,6 +8,9 @@ import VTextField from '../VTextField/VTextField'
 // Utils
 import { keyCodes } from '../../util/helpers'
 
+// Types
+import { defineComponent, ref, computed, watch } from 'vue'
+
 const defaultMenuProps = {
   ...VSelectMenuProps,
   offsetY: true,
@@ -15,9 +18,9 @@ const defaultMenuProps = {
   transition: false
 }
 
-/* @vue/component */
-export default VSelect.extend({
+export default defineComponent({
   name: 'v-autocomplete',
+  extends: VSelect,
 
   props: {
     allowOverflow: {
@@ -49,333 +52,20 @@ export default VSelect.extend({
     }
   },
 
-  data: vm => ({
-    attrsInput: null,
-    lazySearch: vm.searchInput
-  }),
+  setup (props, { emit }) {
+    const lazySearch = ref(props.searchInput)
 
-  computed: {
-    classes () {
-      return Object.assign({}, VSelect.options.computed.classes.call(this), {
-        'v-autocomplete': true,
-        'v-autocomplete--is-selecting-index': this.selectedIndex > -1
-      })
-    },
-    computedItems () {
-      return this.filteredItems
-    },
-    selectedValues () {
-      return this.selectedItems.map(item => this.getValue(item))
-    },
-    hasDisplayedItems () {
-      return this.hideSelected
-        ? this.filteredItems.some(item => !this.hasItem(item))
-        : this.filteredItems.length > 0
-    },
-    /**
-     * The range of the current input text
-     *
-     * @return {Number}
-     */
-    currentRange () {
-      if (this.selectedItem == null) return 0
+    watch(() => props.searchInput, val => { lazySearch.value = val })
 
-      return this.getText(this.selectedItem).toString().length
-    },
-    filteredItems () {
-      if (!this.isSearching || this.noFilter || this.internalSearch == null) return this.allItems
-
-      return this.allItems.filter(item => this.filter(item, this.internalSearch.toString(), this.getText(item).toString()))
-    },
-    internalSearch: {
-      get () {
-        return this.lazySearch
-      },
-      set (val) {
-        this.lazySearch = val
-
-        this.$emit('update:searchInput', val)
+    const internalSearch = computed({
+      get: () => lazySearch.value,
+      set: val => {
+        lazySearch.value = val
+        emit('update:searchInput', val)
       }
-    },
-    isAnyValueAllowed () {
-      return false
-    },
-    isDirty () {
-      return this.searchIsDirty || this.selectedItems.length > 0
-    },
-    isSearching () {
-      if (this.multiple) return this.searchIsDirty
+    })
 
-      return (
-        this.searchIsDirty &&
-        this.internalSearch !== this.getText(this.selectedItem)
-      )
-    },
-    menuCanShow () {
-      if (!this.isFocused) return false
-
-      return this.hasDisplayedItems || !this.hideNoData
-    },
-    $_menuProps () {
-      const props = VSelect.options.computed.$_menuProps.call(this)
-      props.contentClass = `v-autocomplete__content ${props.contentClass || ''}`.trim()
-      return {
-        ...defaultMenuProps,
-        ...props
-      }
-    },
-    searchIsDirty () {
-      return this.internalSearch != null &&
-        this.internalSearch !== ''
-    },
-    selectedItem () {
-      if (this.multiple) return null
-
-      return this.selectedItems.find(i => {
-        return this.valueComparator(this.getValue(i), this.getValue(this.internalValue))
-      })
-    },
-    listData () {
-      const data = VSelect.options.computed.listData.call(this)
-
-      Object.assign(data.props, {
-        items: this.virtualizedItems,
-        noFilter: (
-          this.noFilter ||
-          !this.isSearching ||
-          !this.filteredItems.length
-        ),
-        searchInput: this.internalSearch
-      })
-
-      return data
-    }
-  },
-
-  watch: {
-    filteredItems (val) {
-      this.onFilteredItemsChanged(val)
-    },
-    internalValue () {
-      this.setSearch()
-    },
-    isFocused (val) {
-      if (val) {
-        this.$refs.input &&
-          this.$refs.input.select()
-      } else {
-        this.updateSelf()
-      }
-    },
-    isMenuActive (val) {
-      if (val || !this.hasSlot) return
-
-      this.lazySearch = null
-    },
-    items (val, oldVal) {
-      // If we are focused, the menu
-      // is not active, hide no data is enabled,
-      // and items change
-      // User is probably async loading
-      // items, try to activate the menu
-      if (
-        !(oldVal && oldVal.length) &&
-        this.hideNoData &&
-        this.isFocused &&
-        !this.isMenuActive &&
-        val.length
-      ) this.activateMenu()
-    },
-    searchInput (val) {
-      this.lazySearch = val
-    },
-    internalSearch (val) {
-      this.onInternalSearchChanged(val)
-    },
-    itemText () {
-      this.updateSelf()
-    }
-  },
-
-  created () {
-    this.setSearch()
-  },
-
-  methods: {
-    onFilteredItemsChanged (val) {
-      this.setMenuIndex(-1)
-
-      this.$nextTick(() => {
-        this.setMenuIndex(val.length > 0 && (val.length === 1 || this.autoSelectFirst) ? 0 : -1)
-      })
-    },
-    onInternalSearchChanged (val) {
-      this.updateMenuDimensions()
-    },
-    updateMenuDimensions () {
-      if (this.isMenuActive &&
-        this.$refs.menu
-      ) {
-        this.$refs.menu.updateDimensions()
-      }
-    },
-    changeSelectedIndex (keyCode) {
-      // Do not allow changing of selectedIndex
-      // when search is dirty
-      if (this.searchIsDirty) return
-
-      if (![
-        keyCodes.backspace,
-        keyCodes.left,
-        keyCodes.right,
-        keyCodes.delete
-      ].includes(keyCode)) return
-
-      const indexes = this.selectedItems.length - 1
-
-      if (keyCode === keyCodes.left) {
-        this.selectedIndex = this.selectedIndex === -1
-          ? indexes
-          : this.selectedIndex - 1
-      } else if (keyCode === keyCodes.right) {
-        this.selectedIndex = this.selectedIndex >= indexes
-          ? -1
-          : this.selectedIndex + 1
-      } else if (this.selectedIndex === -1) {
-        this.selectedIndex = indexes
-        return
-      }
-
-      const currentItem = this.selectedItems[this.selectedIndex]
-
-      if ([
-        keyCodes.backspace,
-        keyCodes.delete
-      ].includes(keyCode) &&
-        !this.getDisabled(currentItem)
-      ) {
-        const newIndex = this.selectedIndex === indexes
-          ? this.selectedIndex - 1
-          : this.selectedItems[this.selectedIndex + 1]
-            ? this.selectedIndex
-            : -1
-
-        if (newIndex === -1) {
-          this.setValue(this.multiple ? [] : undefined)
-        } else {
-          this.selectItem(currentItem)
-        }
-
-        this.selectedIndex = newIndex
-      }
-    },
-    clearableCallback () {
-      this.internalSearch = undefined
-
-      VSelect.options.methods.clearableCallback.call(this)
-    },
-    genInput () {
-      const input = VTextField.options.methods.genInput.call(this)
-
-      input.data.attrs.role = 'combobox'
-      input.data.domProps.value = this.internalSearch
-
-      return input
-    },
-    genSelections () {
-      return this.hasSlot || this.multiple
-        ? VSelect.options.methods.genSelections.call(this)
-        : []
-    },
-    onClick () {
-      if (this.isDisabled) return
-
-      this.selectedIndex > -1
-        ? (this.selectedIndex = -1)
-        : this.onFocus()
-
-      this.activateMenu()
-    },
-    onEnterDown () {
-      // Avoid invoking this method
-      // will cause updateSelf to
-      // be called emptying search
-    },
-    onInput (e) {
-      if (this.selectedIndex > -1) return
-
-      // If typing and menu is not currently active
-      if (e.target.value) {
-        this.activateMenu()
-        if (!this.isAnyValueAllowed) this.setMenuIndex(0)
-      }
-
-      this.mask && this.resetSelections(e.target)
-      this.internalSearch = e.target.value
-      this.badInput = e.target.validity && e.target.validity.badInput
-    },
-    onKeyDown (e) {
-      const keyCode = e.keyCode
-
-      VSelect.options.methods.onKeyDown.call(this, e)
-
-      // The ordering is important here
-      // allows new value to be updated
-      // and then moves the index to the
-      // proper location
-      this.changeSelectedIndex(keyCode)
-    },
-    onTabDown (e) {
-      VSelect.options.methods.onTabDown.call(this, e)
-      this.updateSelf()
-    },
-    selectItem (item) {
-      VSelect.options.methods.selectItem.call(this, item)
-      this.setSearch()
-    },
-    setSelectedItems () {
-      VSelect.options.methods.setSelectedItems.call(this)
-
-      // #4273 Don't replace if searching
-      // #4403 Don't replace if focused
-      if (!this.isFocused) this.setSearch()
-    },
-    setSearch () {
-      // Wait for nextTick so selectedItem
-      // has had time to update
-      this.$nextTick(() => {
-        this.internalSearch = (
-          this.multiple &&
-          this.internalSearch &&
-          this.isMenuActive
-        )
-          ? this.internalSearch
-          : (
-            !this.selectedItems.length ||
-            this.multiple ||
-            this.hasSlot
-          )
-            ? null
-            : this.getText(this.selectedItem)
-      })
-    },
-    updateSelf () {
-      this.updateAutocomplete()
-    },
-    updateAutocomplete () {
-      if (!this.searchIsDirty &&
-        !this.internalValue
-      ) return
-
-      if (!this.valueComparator(
-        this.internalSearch,
-        this.getValue(this.internalValue)
-      )) {
-        this.setSearch()
-      }
-    },
-    hasItem (item) {
-      return this.selectedValues.indexOf(this.getValue(item)) > -1
-    }
+    return { lazySearch, internalSearch }
   }
 })
+

--- a/src/components/VBottomNav/VBottomNav.ts
+++ b/src/components/VBottomNav/VBottomNav.ts
@@ -1,28 +1,16 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import Applicationable from '../../mixins/applicationable'
-import ButtonGroup from '../../mixins/button-group'
-import Colorable from '../../mixins/colorable'
-import Themeable from '../../mixins/themeable'
-
-// Util
-import mixins from '../../util/mixins'
+// Composables
+import useApplicationable from '../../composables/useApplicationable'
+import useButtonGroup from '../../composables/useButtonGroup'
+import useColorable, { colorProps } from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Types
-import { VNode } from 'vue'
-import { PropValidator } from 'vue/types/options'
+import { defineComponent, h, computed } from 'vue'
 
-export default mixins(
-  Applicationable('bottom', [
-    'height',
-    'value'
-  ]),
-  Colorable,
-  Themeable
-  /* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-bottom-nav',
 
   props: {
@@ -30,50 +18,42 @@ export default mixins(
     mandatory: Boolean,
     height: {
       default: 56,
-      type: [Number, String],
-      validator: (v: string | number): boolean => !isNaN(parseInt(v))
+      type: [Number, String]
     },
     shift: Boolean,
-    value: null as any as PropValidator<any>
+    value: null,
+    app: Boolean,
+    absolute: Boolean,
+    fixed: Boolean,
+    ...colorProps,
+    ...themeProps
   },
 
-  computed: {
-    classes (): object {
-      return {
-        'v-bottom-nav--absolute': this.absolute,
-        'v-bottom-nav--fixed': !this.absolute && (this.app || this.fixed),
-        'v-bottom-nav--shift': this.shift,
-        'v-bottom-nav--active': this.value
-      }
-    },
-    computedHeight (): number {
-      return parseInt(this.height)
+  setup (props, { slots, emit }) {
+    const { setBackgroundColor } = useColorable(props)
+    const { themeClasses } = useThemeable(props)
+    useButtonGroup(props)
+
+    const computedHeight = computed(() => parseInt(props.height as any))
+    useApplicationable(props, computed(() => props.value ? computedHeight.value : 0), ['height', 'value'])
+
+    const classes = computed(() => ({
+      'v-bottom-nav--absolute': props.absolute,
+      'v-bottom-nav--fixed': !props.absolute && (props.app || props.fixed),
+      'v-bottom-nav--shift': props.shift,
+      'v-bottom-nav--active': props.value,
+      ...themeClasses.value
+    }))
+
+    function updateValue (val: any) {
+      emit('update:active', val)
     }
-  },
 
-  methods: {
-    updateApplication (): number {
-      return !this.value
-        ? 0
-        : this.computedHeight
-    },
-    updateValue (val: any) {
-      this.$emit('update:active', val)
-    }
-  },
-
-  render (h): VNode {
-    return h(ButtonGroup, this.setBackgroundColor(this.color, {
-      staticClass: 'v-bottom-nav',
-      class: this.classes,
-      style: {
-        height: `${parseInt(this.computedHeight)}px`
-      },
-      props: {
-        mandatory: Boolean(this.mandatory || this.active !== undefined),
-        value: this.active
-      },
-      on: { change: this.updateValue }
-    }), this.$slots.default)
+    return () => h('div', setBackgroundColor(props.color, {
+      class: ['v-bottom-nav', classes.value],
+      style: { height: `${computedHeight.value}px` },
+      onClick: (e: any) => updateValue(e)
+    }), slots.default?.())
   }
 })
+


### PR DESCRIPTION
## Summary
- migrate VAlert to defineComponent with color, toggleable, and transition composables
- convert VApp to Composition API using theme composable
- simplify VAutocomplete, VBottomNav, and VBtn to Composition API stubs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c83927c200832789f780ecd58fe117