### PR TITLE
refactor components to Composition API

### DIFF
--- a/src/components/VGrid/VContainer.js
+++ b/src/components/VGrid/VContainer.js
@@ -1,5 +1,41 @@
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-import Grid from './grid'
+import { defineComponent, h } from 'vue'
 
-export default Grid('container')
+export default defineComponent({
+  name: 'v-container',
+
+  props: {
+    id: String,
+    tag: {
+      type: String,
+      default: 'div',
+    },
+  },
+
+  setup (props, { attrs, slots }) {
+    return () => {
+      const classList = ['container']
+      const dataAttrs = {}
+
+      Object.keys(attrs).forEach(key => {
+        const value = attrs[key]
+        if (key === 'class' || key === 'style') return
+        if (key === 'slot') return
+        if (key.startsWith('data-')) {
+          dataAttrs[key] = value
+          return
+        }
+        if (value || typeof value === 'string') classList.push(key)
+      })
+
+      if (attrs.class) classList.push(attrs.class)
+
+      const data = { class: classList, ...dataAttrs }
+      if (props.id) data.id = props.id
+
+      return h(props.tag, data, slots.default?.())
+    }
+  }
+})
+

--- a/src/components/VGrid/VContent.js
+++ b/src/components/VGrid/VContent.js
@@ -1,50 +1,41 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Mixins
-import SSRBootable from '../../mixins/ssr-bootable'
+// Composables
+import useSsrBootable from '../../composables/useSsrBootable'
 
-/* @vue/component */
-export default {
+// Types
+import { defineComponent, h, computed, getCurrentInstance } from 'vue'
+
+export default defineComponent({
   name: 'v-content',
-
-  mixins: [SSRBootable],
 
   props: {
     tag: {
       type: String,
-      default: 'main'
-    }
+      default: 'main',
+    },
   },
 
-  computed: {
-    styles () {
-      const {
-        bar, top, right, footer, insetFooter, bottom, left
-      } = this.$vuetify.application
+  setup (props, { slots }) {
+    useSsrBootable()
+    const vm = getCurrentInstance()
 
+    const styles = computed(() => {
+      const { bar, top, right, footer, insetFooter, bottom, left } = vm?.proxy.$vuetify.application
       return {
         paddingTop: `${top + bar}px`,
         paddingRight: `${right}px`,
         paddingBottom: `${footer + insetFooter + bottom}px`,
-        paddingLeft: `${left}px`
+        paddingLeft: `${left}px`,
       }
-    }
-  },
+    })
 
-  render (h) {
-    const data = {
-      staticClass: 'v-content',
-      style: this.styles,
-      ref: 'content'
-    }
-
-    return h(this.tag, data, [
-      h(
-        'div',
-        { staticClass: 'v-content__wrap' },
-        this.$slots.default
-      )
-    ])
+    return () => h(props.tag, {
+      class: 'v-content',
+      style: styles.value,
+      ref: 'content',
+    }, [h('div', { class: 'v-content__wrap' }, slots.default?.())])
   }
-}
+})
+


### PR DESCRIPTION
## Summary
- rewrite VExpansionPanelContent with defineComponent and composables
- convert VFooter and VForm to Composition API using color, theme, application, and registrable composables
- migrate VContainer and VContent to defineComponent

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint` *(sh: 1: lerna: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c83ad91a588327a11beb3bce72e670