### PR TITLE
refactor: use defineComponent and composables

### DIFF
--- a/src/components/VDivider/VDivider.ts
+++ b/src/components/VDivider/VDivider.ts
@@ -1,30 +1,32 @@
 // Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
+
+// Composables
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Types
-import { VNode } from 'vue'
+import { defineComponent, h } from 'vue'
 
-// Mixins
-import Themeable from '../../mixins/themeable'
-
-export default Themeable.extend({
+export default defineComponent({
   name: 'v-divider',
 
   props: {
+    ...themeProps,
     inset: Boolean,
     vertical: Boolean
   },
 
-  render (h): VNode {
-    return h('hr', {
+  setup (props, { attrs }) {
+    const { themeClasses } = useThemeable(props)
+
+    return () => h('hr', {
       class: {
         'v-divider': true,
-        'v-divider--inset': this.inset,
-        'v-divider--vertical': this.vertical,
-        ...this.themeClasses
+        'v-divider--inset': props.inset,
+        'v-divider--vertical': props.vertical,
+        ...themeClasses.value
       },
-      attrs: this.$attrs,
-      on: this.$listeners
+      ...attrs
     })
   }
 })


### PR DESCRIPTION
## Summary
- refactor VDatePicker title and years components to use defineComponent with picker and color composables
- migrate VDialog, VDivider, and VExpansionPanel to Composition API with corresponding composables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c83ad825648327a272dc1655a4ff05