### PR TITLE
refactor: migrate components to Composition API

### DIFF
--- a/src/components/VDataIterator/VDataIterator.js
+++ b/src/components/VDataIterator/VDataIterator.js
@@ -1,12 +1,14 @@
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-import DataIterable from '../../mixins/data-iterable'
+// Composables
+import useDataIterable, { dataIterableProps } from '../../composables/useDataIterable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
-/* @vue/component */
-export default {
+// Types
+import { defineComponent, h } from 'vue'
+
+export default defineComponent({
   name: 'v-data-iterator',
-
-  mixins: [DataIterable],
 
   inheritAttrs: false,
 
@@ -22,89 +24,77 @@ export default {
     contentClass: {
       type: String,
       required: false
-    }
+    },
+    ...dataIterableProps,
+    ...themeProps
   },
 
-  computed: {
-    classes () {
+  setup (props, { attrs, slots, emit }) {
+    const iterable = useDataIterable(props, emit)
+    const { themeClasses } = useThemeable(props)
+
+    iterable.initPagination()
+
+    function classes () {
       return {
         'v-data-iterator': true,
-        'v-data-iterator--select-all': this.selectAll !== false,
-        ...this.themeClasses
+        'v-data-iterator--select-all': props.selectAll !== false,
+        ...themeClasses.value
       }
     }
-  },
 
-  created () {
-    this.initPagination()
-  },
-
-  methods: {
-    genContent () {
-      const children = this.genItems()
-
-      const data = {
-        'class': this.contentClass,
-        attrs: this.$attrs,
-        on: this.$listeners,
-        props: this.contentProps
-      }
-
-      return this.$createElement(this.contentTag, data, children)
-    },
-    genEmptyItems (content) {
-      return [this.$createElement('div', {
-        'class': 'text-xs-center',
+    function genEmptyItems (content) {
+      return [h('div', {
+        class: 'text-xs-center',
         style: 'width: 100%'
       }, content)]
-    },
-    genFilteredItems () {
-      if (!this.$scopedSlots.item) {
-        return null
-      }
-
-      const items = []
-      for (let index = 0, len = this.filteredItems.length; index < len; ++index) {
-        const item = this.filteredItems[index]
-        const props = this.createProps(item, index)
-        items.push(this.$scopedSlots.item(props))
-      }
-
-      return items
-    },
-    genFooter () {
-      const children = []
-
-      if (this.$slots.footer) {
-        children.push(this.$slots.footer)
-      }
-
-      if (!this.hideActions) {
-        children.push(this.genActions())
-      }
-
-      if (!children.length) return null
-      return this.$createElement('div', children)
-    },
-    genHeader () {
-      const children = []
-
-      if (this.$slots.header) {
-        children.push(this.$slots.header)
-      }
-
-      if (!children.length) return null
-      return this.$createElement('div', children)
     }
-  },
 
-  render (h) {
-    return h('div', {
-      'class': this.classes
-    }, [
-      this.genHeader(),
-      this.genContent(),
-      this.genFooter()
+    function genFilteredItems () {
+      if (!slots.item) return null
+      const items = []
+      for (let index = 0, len = iterable.filteredItems.value.length; index < len; ++index) {
+        const item = iterable.filteredItems.value[index]
+        const propsOut = iterable.createProps(item, index)
+        items.push(slots.item(propsOut))
+      }
+      return items
+    }
+
+    function genItems () {
+      const items = genFilteredItems()
+      if (items && items.length) return items
+      return genEmptyItems(slots['no-results'] ? slots['no-results']() : props.noResultsText)
+    }
+
+    function genContent () {
+      const children = genItems()
+      const data = {
+        class: props.contentClass,
+        ...attrs,
+        props: props.contentProps
+      }
+      return h(props.contentTag, data, children)
+    }
+
+    function genFooter () {
+      const children = []
+      if (slots.footer) children.push(slots.footer())
+      if (!props.hideActions) children.push(iterable.genActions ? iterable.genActions() : null)
+      return children.length ? h('div', children) : null
+    }
+
+    function genHeader () {
+      const children = []
+      if (slots.header) children.push(slots.header())
+      return children.length ? h('div', children) : null
+    }
+
+    return () => h('div', { class: classes() }, [
+      genHeader(),
+      genContent(),
+      genFooter()
     ])
   }
-}
+})
+


### PR DESCRIPTION
## Summary
- refactor VCheckbox to use Composition API and composables
- rewrite VChip with defineComponent and reactive setup
- migrate VCombobox, VDataIterator, and VDataTable away from mixins

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c83ad287c083278abbb121365b14a4