### PR TITLE
refactor: migrate card and carousel components to composition API

### DIFF
--- a/src/components/VCard/VCard.ts
+++ b/src/components/VCard/VCard.ts
@@ -1,59 +1,65 @@
 // Styles
 import "@/css/vuetify.css"
 
-// Extensions
-import VSheet from '../VSheet'
+// Vue
+import { defineComponent, h, computed } from 'vue'
 
-// Mixins
-import Routable from '../../mixins/routable'
+// Composables
+import useRoutable, { routableProps } from '../../composables/useRoutable'
+import useColorable, { colorProps, setBackgroundColor } from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
+import useElevatable from '../../composables/useElevatable'
+import useMeasurable, { measurableProps } from '../../composables/useMeasurable'
 
-// Helpers
-import mixins from '../../util/mixins'
-
-// Types
-import { VNode } from 'vue'
-
-/* @vue/component */
-export default mixins(
-  Routable,
-  VSheet
-).extend({
+export default defineComponent({
   name: 'v-card',
 
   props: {
     flat: Boolean,
     hover: Boolean,
     img: String,
-    raised: Boolean
-  },
-
-  computed: {
-    classes (): object {
-      return {
-        'v-card': true,
-        'v-card--flat': this.flat,
-        'v-card--hover': this.hover,
-        ...VSheet.options.computed.classes.call(this)
-      }
+    raised: Boolean,
+    tag: {
+      type: String,
+      default: 'div'
     },
-    styles (): object {
-      const style: Dictionary<string> = {
-        ...VSheet.options.computed.styles.call(this)
-      }
-
-      if (this.img) {
-        style.background = `url("${this.img}") center center / cover no-repeat`
-      }
-
-      return style
-    }
+    tile: Boolean,
+    elevation: [Number, String],
+    ...colorProps,
+    ...themeProps,
+    ...measurableProps,
+    ...routableProps
   },
 
-  render (h): VNode {
-    const { tag, data } = this.generateRouteLink(this.classes)
+  setup (props, { slots, attrs, emit }) {
+    const { generateRouteLink } = useRoutable(props, { attrs, emit })
+    const { setBackgroundColor } = useColorable(props)
+    const { themeClasses } = useThemeable(props)
+    const { elevationClasses } = useElevatable(props)
+    const { measurableStyles } = useMeasurable(props)
 
-    data.style = this.styles
+    const classes = computed(() => ({
+      'v-card': true,
+      'v-card--flat': props.flat,
+      'v-card--hover': props.hover,
+      'v-sheet': true,
+      'v-sheet--tile': props.tile,
+      ...themeClasses.value,
+      ...elevationClasses.value
+    }))
 
-    return h(tag, this.setBackgroundColor(this.color, data), this.$slots.default)
+    const styles = computed(() => {
+      const style = { ...measurableStyles.value } as any
+      if (props.img) {
+        style.background = `url("${props.img}") center center / cover no-repeat`
+      }
+      return style
+    })
+
+    return () => {
+      const { tag, data } = generateRouteLink(classes.value)
+      data.style = styles.value
+      return h(tag, setBackgroundColor(props.color, data), slots.default?.())
+    }
   }
 })

--- a/src/components/VCard/VCardMedia.ts
+++ b/src/components/VCard/VCardMedia.ts
@@ -4,12 +4,17 @@ import VImg from '../VImg/VImg'
 // Utils
 import { deprecate } from '../../util/console'
 
-/* istanbul ignore next */
-/* @vue/component */
-export default VImg.extend({
-  name: 'v-card-media',
+// Vue
+import { defineComponent, onMounted } from 'vue'
 
-  mounted () {
-    deprecate('v-card-media', this.src ? 'v-img' : 'v-responsive', this)
+/* istanbul ignore next */
+export default defineComponent({
+  name: 'v-card-media',
+  extends: VImg,
+  setup (props) {
+    onMounted(() => {
+      deprecate('v-card-media', props.src ? 'v-img' : 'v-responsive')
+    })
+    return {}
   }
 })

--- a/src/components/VCard/VCardTitle.ts
+++ b/src/components/VCard/VCardTitle.ts
@@ -1,21 +1,19 @@
-// Types
-import Vue, { VNode } from 'vue'
+// Vue
+import { defineComponent, h } from 'vue'
 
-/* @vue/component */
-export default Vue.extend({
+export default defineComponent({
   name: 'v-card-title',
-
-  functional: true,
 
   props: {
     primaryTitle: Boolean
   },
 
-  render (h, { data, props, children }): VNode {
-    data.staticClass = (`v-card__title ${data.staticClass || ''}`).trim()
-
-    if (props.primaryTitle) data.staticClass += ' v-card__title--primary'
-
-    return h('div', data, children)
+  setup (props, { slots, attrs }) {
+    return () => {
+      const data: any = { ...attrs }
+      data.class = (`v-card__title ${data.class || ''}`).trim()
+      if (props.primaryTitle) data.class += ' v-card__title--primary'
+      return h('div', data, slots.default?.())
+    }
   }
 })

--- a/src/components/VCarousel/VCarousel.ts
+++ b/src/components/VCarousel/VCarousel.ts
@@ -8,241 +8,195 @@ import VWindow from '../VWindow/VWindow'
 import VBtn from '../VBtn'
 import VIcon from '../VIcon'
 
-// Mixins
-// TODO: Move this into core components v2.0
-import ButtonGroup from '../../mixins/button-group'
-
 // Utilities
 import { convertToUnit } from '../../util/helpers'
 import { deprecate } from '../../util/console'
 
-// Types
-import { VNode } from 'vue'
+// Vue
+import { defineComponent, h, ref, watch, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
 import { VNodeDirective } from 'vue/types/vnode'
 
-export default VWindow.extend({
+export default defineComponent({
   name: 'v-carousel',
+  extends: VWindow,
 
   props: {
     cycle: {
       type: Boolean,
-      default: true
+      default: true,
     },
     delimiterIcon: {
       type: String,
-      default: '$vuetify.icons.delimiter'
+      default: '$vuetify.icons.delimiter',
     },
     height: {
       type: [Number, String],
-      default: 500
+      default: 500,
     },
     hideControls: Boolean,
     hideDelimiters: Boolean,
     interval: {
       type: [Number, String],
       default: 6000,
-      validator: (value: string | number) => value > 0
+      validator: (value: string | number) => value > 0,
     },
     mandatory: {
       type: Boolean,
-      default: true
+      default: true,
     },
     nextIcon: {
       type: [Boolean, String],
-      default: '$vuetify.icons.next'
+      default: '$vuetify.icons.next',
     },
     prevIcon: {
       type: [Boolean, String],
-      default: '$vuetify.icons.prev'
-    }
-  },
-
-  data () {
-    return {
-      changedByDelimiters: false,
-      internalHeight: this.height,
-      slideTimeout: undefined as number | undefined
-    }
-  },
-
-  computed: {
-    isDark (): boolean {
-      return this.dark || !this.light
-    }
-  },
-
-  watch: {
-    internalValue (val) {
-      this.restartTimeout()
-      /* @deprecate */
-      /* istanbul ignore else */
-      if (!this.$listeners['input']) return
-
-      this.$emit('input', val)
+      default: '$vuetify.icons.prev',
     },
-    interval: 'restartTimeout',
-    height (val, oldVal) {
-      if (val === oldVal || !val) return
-      this.internalHeight = val
-    },
-    cycle (val) {
-      if (val) {
-        this.restartTimeout()
-      } else {
-        clearTimeout(this.slideTimeout)
-        this.slideTimeout = undefined
+  },
+
+  setup (props, { attrs, emit }) {
+    const vm = getCurrentInstance()!
+    const proxy: any = vm.proxy
+    const changedByDelimiters = ref(false)
+    let slideTimeout: number | undefined
+
+    function restartTimeout () {
+      slideTimeout && clearTimeout(slideTimeout)
+      slideTimeout = undefined
+      const raf = requestAnimationFrame || setTimeout
+      raf(startTimeout)
+    }
+
+    function startTimeout () {
+      if (!props.cycle) return
+      slideTimeout = window.setTimeout(proxy.next, +props.interval > 0 ? +props.interval : 6000)
+    }
+
+    function updateReverse (val: number, oldVal: number) {
+      if (changedByDelimiters.value) {
+        changedByDelimiters.value = false
+        return
       }
+      VWindow.options.methods.updateReverse.call(proxy, val, oldVal)
     }
-  },
 
-  mounted () {
-    /* @deprecate */
-    /* istanbul ignore next */
-    if (this.$listeners['input']) {
-      deprecate('@input', '@change', this)
-    }
-    this.startTimeout()
-  },
+    Object.assign(proxy, { updateReverse })
 
-  methods: {
-    genDelimiters (): VNode {
-      return this.$createElement('div', {
-        staticClass: 'v-carousel__controls'
-      }, [this.genItems()])
-    },
-    genIcon (
-      direction: 'prev' | 'next',
-      icon: string,
-      fn: () => void
-    ): VNode {
-      return this.$createElement('div', {
-        staticClass: `v-carousel__${direction}`
-      }, [
-        this.$createElement(VBtn, {
-          props: {
-            icon: true
-          },
+    watch(() => proxy.internalValue, val => {
+      restartTimeout()
+      emit('input', val)
+    })
+
+    watch(() => props.interval, restartTimeout)
+
+    watch(() => props.height, (val, oldVal) => {
+      if (val === oldVal || !val) return
+      proxy.internalHeight = val
+    })
+
+    watch(() => props.cycle, val => {
+      if (val) restartTimeout()
+      else {
+        clearTimeout(slideTimeout)
+        slideTimeout = undefined
+      }
+    })
+
+    onMounted(() => {
+      if ((attrs as any).on && (attrs as any).on.input) {
+        deprecate('@input', '@change', proxy)
+      }
+      startTimeout()
+    })
+
+    onBeforeUnmount(() => {
+      clearTimeout(slideTimeout)
+    })
+
+    function genIcon (direction: 'prev' | 'next', icon: string, fn: () => void) {
+      return h('div', { class: `v-carousel__${direction}` }, [
+        h(VBtn, {
+          props: { icon: true },
           attrs: {
-            'aria-label': this.$vuetify.t(`$vuetify.carousel.${direction}`)
+            'aria-label': proxy.$vuetify.t(`$vuetify.carousel.${direction}`)
           },
           on: {
             click: () => {
-              this.changedByDelimiters = true
+              changedByDelimiters.value = true
               fn()
             }
           }
         }, [
-          this.$createElement(VIcon, {
-            props: { 'size': '46px' }
-          }, icon)
+          h(VIcon, { props: { size: '46px' } }, icon)
         ])
       ])
-    },
-    genIcons (): VNode[] {
-      const icons = []
+    }
 
-      const prevIcon = this.$vuetify.rtl
-        ? this.nextIcon
-        : this.prevIcon
-
+    function genIcons () {
+      const icons: any[] = []
+      const prevIcon = proxy.$vuetify.rtl ? props.nextIcon : props.prevIcon
       if (prevIcon && typeof prevIcon === 'string') {
-        icons.push(this.genIcon('prev', prevIcon, this.prev))
+        icons.push(genIcon('prev', prevIcon as string, proxy.prev))
       }
-
-      const nextIcon = this.$vuetify.rtl
-        ? this.prevIcon
-        : this.nextIcon
-
+      const nextIcon = proxy.$vuetify.rtl ? props.prevIcon : props.nextIcon
       if (nextIcon && typeof nextIcon === 'string') {
-        icons.push(this.genIcon('next', nextIcon, this.next))
+        icons.push(genIcon('next', nextIcon as string, proxy.next))
       }
-
       return icons
-    },
-    genItems (): VNode {
-      const length = this.items.length
-      const children = []
+    }
 
+    function genItems () {
+      const length = proxy.items.length
+      const children = []
       for (let i = 0; i < length; i++) {
-        const child = this.$createElement(VBtn, {
+        const value = proxy.getValue(proxy.items[i], i)
+        const child = h(VBtn, {
           class: {
-            'v-carousel__controls__item': true
+            'v-carousel__controls__item': true,
+            'v-btn--active': proxy.internalValue === value
           },
           props: {
             icon: true,
             small: true,
-            value: this.getValue(this.items[i], i)
+            value
+          },
+          on: {
+            click: () => {
+              changedByDelimiters.value = true
+              proxy.internalValue = value
+            }
           }
         }, [
-          this.$createElement(VIcon, {
-            props: { size: 18 }
-          }, this.delimiterIcon)
+          h(VIcon, { props: { size: 18 } }, props.delimiterIcon)
         ])
-
         children.push(child)
       }
+      return h('div', {}, children)
+    }
 
-      return this.$createElement(ButtonGroup, {
-        props: {
-          value: this.internalValue
-        },
-        on: {
-          change: (val: any) => {
-            this.internalValue = val
-          }
-        }
-      }, children)
-    },
-    restartTimeout () {
-      this.slideTimeout && clearTimeout(this.slideTimeout)
-      this.slideTimeout = undefined
+    function genDelimiters () {
+      return h('div', { class: 'v-carousel__controls' }, [genItems()])
+    }
 
-      const raf = requestAnimationFrame || setTimeout
-      raf(this.startTimeout)
-    },
-    startTimeout () {
-      if (!this.cycle) return
-
-      this.slideTimeout = window.setTimeout(this.next, +this.interval > 0 ? +this.interval : 6000)
-    },
-    updateReverse (val: number, oldVal: number) {
-      if (this.changedByDelimiters) {
-        this.changedByDelimiters = false
-        return
+    return () => {
+      const children: any[] = []
+      const data: any = {
+        class: 'v-window v-carousel',
+        style: { height: convertToUnit(props.height) },
+        directives: [] as VNodeDirective[]
       }
 
-      VWindow.options.methods.updateReverse.call(this, val, oldVal)
-    }
-  },
+      if (!props.touchless) {
+        data.directives.push({
+          name: 'touch',
+          value: { left: proxy.next, right: proxy.prev }
+        } as VNodeDirective)
+      }
 
-  render (h): VNode {
-    const children = []
-    const data = {
-      staticClass: 'v-window v-carousel',
-      style: {
-        height: convertToUnit(this.height)
-      },
-      directives: [] as VNodeDirective[]
-    }
+      if (!props.hideControls) children.push(genIcons())
+      if (!props.hideDelimiters) children.push(genDelimiters())
 
-    if (!this.touchless) {
-      data.directives.push({
-        name: 'touch',
-        value: {
-          left: this.next,
-          right: this.prev
-        }
-      } as VNodeDirective)
+      return h('div', data, [proxy.genContainer(), children])
     }
-
-    if (!this.hideControls) {
-      children.push(this.genIcons())
-    }
-
-    if (!this.hideDelimiters) {
-      children.push(this.genDelimiters())
-    }
-
-    return h('div', data, [this.genContainer(), children])
   }
 })

--- a/src/components/VCarousel/VCarouselItem.ts
+++ b/src/components/VCarousel/VCarouselItem.ts
@@ -4,29 +4,31 @@ import VWindowItem from '../VWindow/VWindowItem'
 // Components
 import { VImg } from '../VImg'
 
-/* @vue/component */
-export default VWindowItem.extend({
-  name: 'v-carousel-item',
+// Vue
+import { defineComponent, h, getCurrentInstance } from 'vue'
 
+export default defineComponent({
+  name: 'v-carousel-item',
+  extends: VWindowItem,
   inheritAttrs: false,
 
-  methods: {
-    genDefaultSlot () {
-      return [
-        this.$createElement(VImg, {
-          staticClass: 'v-carousel__item',
-          props: {
-            ...this.$attrs,
-            height: this.windowGroup.internalHeight
-          },
-          on: this.$listeners
-        }, this.$slots.default)
-      ]
-    },
-    onBeforeEnter () { /* noop */ },
-    onEnter () { /* noop */ },
-    onAfterEnter () { /* noop */ },
-    onBeforeLeave () { /* noop */ },
-    onEnterCancelled () { /* noop */ }
+  setup (props, { slots, attrs }) {
+    const vm = getCurrentInstance()!
+    const proxy: any = vm.proxy
+
+    function genDefaultSlot () {
+      const data: any = { ...attrs, class: ['v-carousel__item', attrs.class], height: proxy.windowGroup.internalHeight }
+      return [h(VImg, data, slots.default?.())]
+    }
+
+    function onBeforeEnter () {}
+    function onEnter () {}
+    function onAfterEnter () {}
+    function onBeforeLeave () {}
+    function onEnterCancelled () {}
+
+    Object.assign(proxy, { genDefaultSlot, onBeforeEnter, onEnter, onAfterEnter, onBeforeLeave, onEnterCancelled })
+
+    return {}
   }
 })


### PR DESCRIPTION
## Summary
- rewrite VCard with composables and defineComponent
- convert VCardMedia and VCardTitle to setup syntax
- refactor VCarousel and VCarouselItem to Composition API and remove ButtonGroup mixin

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c83ad1b43c8327abce8d8d20589ab7