### PR TITLE
refactor: migrate VDatePicker to composition API

### DIFF
--- a/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/src/components/VDatePicker/VDatePickerHeader.ts
@@ -1,148 +1,148 @@
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
 // Components
 import VBtn from '../VBtn'
 import VIcon from '../VIcon'
 
-// Mixins
-import Colorable from '../../mixins/colorable'
-import Themeable from '../../mixins/themeable'
+// Composables
+import useColorable, { colorProps } from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Utils
 import { createNativeLocaleFormatter, monthChange } from './util'
-import mixins from '../../util/mixins'
 
 // Types
-import { VNode } from 'vue'
-import { DatePickerFormatter } from './util/createNativeLocaleFormatter'
-import { PropValidator } from 'vue/types/options'
+import { computed, defineComponent, getCurrentInstance, h, PropType, ref, Transition, watch } from 'vue'
+import type { DatePickerFormatter } from './util/createNativeLocaleFormatter'
 
-export default mixins(
-  Colorable,
-  Themeable
-/* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-date-picker-header',
 
   props: {
+    ...colorProps,
+    ...themeProps,
     disabled: Boolean,
-    format: Function as PropValidator<DatePickerFormatter | undefined>,
+    format: Function as PropType<DatePickerFormatter | undefined>,
     locale: {
       type: String,
-      default: 'en-us'
+      default: 'en-us',
     },
     min: String,
     max: String,
     nextIcon: {
       type: String,
-      default: '$vuetify.icons.next'
+      default: '$vuetify.icons.next',
     },
     prevIcon: {
       type: String,
-      default: '$vuetify.icons.prev'
+      default: '$vuetify.icons.prev',
     },
     readonly: Boolean,
     value: {
       type: [Number, String],
-      required: true
-    }
-  },
-
-  data () {
-    return {
-      isReversing: false
-    }
-  },
-
-  computed: {
-    formatter (): DatePickerFormatter {
-      if (this.format) {
-        return this.format
-      } else if (String(this.value).split('-')[1]) {
-        return createNativeLocaleFormatter(this.locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }, { length: 7 })
-      } else {
-        return createNativeLocaleFormatter(this.locale, { year: 'numeric', timeZone: 'UTC' }, { length: 4 })
-      }
-    }
-  },
-
-  watch: {
-    value (newVal, oldVal) {
-      this.isReversing = newVal < oldVal
-    }
-  },
-
-  methods: {
-    genBtn (change: number) {
-      const disabled = this.disabled ||
-        (change < 0 && this.min && this.calculateChange(change) < this.min) ||
-        (change > 0 && this.max && this.calculateChange(change) > this.max)
-
-      return this.$createElement(VBtn, {
-        props: {
-          dark: this.dark,
-          disabled,
-          icon: true,
-          light: this.light
-        },
-        nativeOn: {
-          click: (e: Event) => {
-            e.stopPropagation()
-            this.$emit('input', this.calculateChange(change))
-          }
-        }
-      }, [
-        this.$createElement(VIcon, ((change < 0) === !this.$vuetify.rtl) ? this.prevIcon : this.nextIcon)
-      ])
+      required: true,
     },
-    calculateChange (sign: number) {
-      const [year, month] = String(this.value).split('-').map(Number)
+  },
 
-      if (month == null) {
+  emits: ['input', 'toggle'],
+
+  setup (props, { emit, slots }) {
+    const { themeClasses } = useThemeable(props)
+    const { setTextColor } = useColorable(props)
+
+    const vm = getCurrentInstance()
+    const isRtl = computed(() => Boolean(vm?.proxy?.$vuetify?.rtl))
+
+    const isReversing = ref(false)
+
+    watch(() => props.value, (newVal, oldVal) => {
+      isReversing.value = newVal < oldVal
+    })
+
+    const formatter = computed<DatePickerFormatter>(() => {
+      if (props.format) {
+        return props.format as DatePickerFormatter
+      } else if (String(props.value).split('-')[1]) {
+        return createNativeLocaleFormatter(props.locale, { month: 'long', year: 'numeric', timeZone: 'UTC' }, { length: 7 })
+      } else {
+        return createNativeLocaleFormatter(props.locale, { year: 'numeric', timeZone: 'UTC' }, { length: 4 })
+      }
+    })
+
+    const transitionName = computed(() => (isReversing.value === !isRtl.value) ? 'tab-reverse-transition' : 'tab-transition')
+
+    const color = computed(() => !props.disabled && (props.color || 'accent'))
+
+    function calculateChange (sign: number) {
+      const [year, month] = String(props.value).split('-').map(Number)
+
+      if (Number.isNaN(month) || month == null) {
         return `${year + sign}`
       } else {
-        return monthChange(String(this.value), sign)
+        return monthChange(String(props.value), sign)
       }
-    },
-    genHeader () {
-      const color = !this.disabled && (this.color || 'accent')
-      const header = this.$createElement('div', this.setTextColor(color, {
-        key: String(this.value)
-      }), [this.$createElement('button', {
-        attrs: {
-          type: 'button'
+    }
+
+    function genBtn (change: number) {
+      const target = calculateChange(change)
+      const disabled = props.disabled ||
+        (change < 0 && props.min && target < props.min) ||
+        (change > 0 && props.max && target > props.max)
+
+      return h(VBtn, {
+        dark: props.dark,
+        disabled,
+        icon: true,
+        light: props.light,
+        onClick: (e: Event) => {
+          e.stopPropagation()
+          emit('input', target)
         },
-        on: {
-          click: () => this.$emit('toggle')
-        }
-      }, [this.$slots.default || this.formatter(String(this.value))])])
+      }, {
+        default: () => h(VIcon, (change < 0) === !isRtl.value ? props.prevIcon : props.nextIcon),
+      })
+    }
 
-      const transition = this.$createElement('transition', {
-        props: {
-          name: (this.isReversing === !this.$vuetify.rtl) ? 'tab-reverse-transition' : 'tab-transition'
-        }
-      }, [header])
+    function genHeader () {
+      const headerContent = h('button', {
+        type: 'button',
+        onClick: () => emit('toggle'),
+      }, slots.default?.() ?? formatter.value(String(props.value)))
 
-      return this.$createElement('div', {
-        staticClass: 'v-date-picker-header__value',
-        class: {
-          'v-date-picker-header__value--disabled': this.disabled
-        }
+      const colorData = setTextColor(color.value, { class: {}, style: {} } as Record<string, any>)
+
+      const header = h('div', {
+        key: String(props.value),
+        class: colorData.class,
+        style: colorData.style,
+      }, [headerContent])
+
+      const transition = h(Transition, { name: transitionName.value }, {
+        default: () => [header],
+      })
+
+      return h('div', {
+        class: [
+          'v-date-picker-header__value',
+          {
+            'v-date-picker-header__value--disabled': props.disabled,
+          },
+        ],
       }, [transition])
     }
-  },
 
-  render (): VNode {
-    return this.$createElement('div', {
-      staticClass: 'v-date-picker-header',
-      class: {
-        'v-date-picker-header--disabled': this.disabled,
-        ...this.themeClasses
-      }
+    return () => h('div', {
+      class: [
+        'v-date-picker-header',
+        {
+          'v-date-picker-header--disabled': props.disabled,
+        },
+        themeClasses.value,
+      ],
     }, [
-      this.genBtn(-1),
-      this.genHeader(),
-      this.genBtn(+1)
+      genBtn(-1),
+      genHeader(),
+      genBtn(+1),
     ])
-  }
+  },
 })

--- a/src/composables/useDatePickerTable.ts
+++ b/src/composables/useDatePickerTable.ts
@@ -1,0 +1,204 @@
+import { computed, getCurrentInstance, h, ref, watch, withDirectives, Transition } from 'vue'
+
+// Directives
+import Touch, { TouchWrapper } from '../directives/touch'
+
+// Composables
+import useColorable, { colorProps, setBackgroundColor } from './useColorable'
+import useThemeable, { themeProps } from './useThemeable'
+
+// Utils
+import isDateAllowed, { AllowedDateFunction } from '../components/VDatePicker/util/isDateAllowed'
+
+// Types
+import type { PropType, VNode, VNodeArrayChildren } from 'vue'
+import type { DatePickerFormatter } from '../components/VDatePicker/util/createNativeLocaleFormatter'
+import type { DateEventColors, DateEventColorValue, DateEvents } from '../components/VDatePicker/VDatePicker'
+
+type CalculateTableDateFunction = (value: number) => string
+
+type EmitFn = (event: string, ...args: any[]) => void
+
+export const datePickerTableProps = {
+  ...colorProps,
+  ...themeProps,
+  allowedDates: Function as PropType<AllowedDateFunction | undefined>,
+  current: String,
+  disabled: Boolean,
+  format: Function as PropType<DatePickerFormatter | undefined>,
+  events: {
+    type: [Array, Function, Object] as PropType<DateEvents>,
+    default: () => null,
+  },
+  eventColor: {
+    type: [Array, Function, Object, String] as PropType<DateEventColors>,
+    default: () => 'warning',
+  },
+  locale: {
+    type: String,
+    default: 'en-us',
+  },
+  min: String,
+  max: String,
+  readonly: Boolean,
+  scrollable: Boolean,
+  tableDate: {
+    type: String,
+    required: true,
+  },
+  value: [String, Array] as PropType<string | string[] | null>,
+}
+
+export default function useDatePickerTable (props: any, emit: EmitFn) {
+  const { themeClasses } = useThemeable(props)
+  const { setBackgroundColor: setBgColor, setTextColor: setTxtColor } = useColorable(props)
+
+  const vm = getCurrentInstance()
+  const isRtl = computed(() => Boolean(vm?.proxy?.$vuetify?.rtl))
+
+  const isReversing = ref(false)
+
+  watch(() => props.tableDate, (newVal: string, oldVal: string | undefined) => {
+    if (oldVal == null) return
+    isReversing.value = newVal < oldVal
+  })
+
+  const computedTransition = computed(() =>
+    (isReversing.value === !isRtl.value) ? 'tab-reverse-transition' : 'tab-transition'
+  )
+
+  const displayedMonth = computed(() => {
+    const parts = String(props.tableDate).split('-')
+    const month = parts[1]
+    return month != null ? Number(month) - 1 : 0
+  })
+
+  const displayedYear = computed(() => Number(String(props.tableDate).split('-')[0]))
+
+  function genButtonClasses (isAllowed: boolean, isFloating: boolean, isSelected: boolean, isCurrent: boolean) {
+    return {
+      'v-btn--active': isSelected,
+      'v-btn--flat': !isSelected,
+      'v-btn--icon': isSelected && isAllowed && isFloating,
+      'v-btn--floating': isFloating,
+      'v-btn--depressed': !isFloating && isSelected,
+      'v-btn--disabled': !isAllowed || (props.disabled && isSelected),
+      'v-btn--outline': isCurrent && !isSelected,
+      ...themeClasses.value,
+    }
+  }
+
+  function getEventColors (date: string) {
+    const arrayize = (v: string | string[]) => Array.isArray(v) ? v : [v]
+    let eventData: boolean | DateEventColorValue
+    let eventColors: string[] = []
+
+    if (Array.isArray(props.events)) {
+      eventData = props.events.includes(date)
+    } else if (typeof props.events === 'function') {
+      eventData = props.events(date) || false
+    } else if (props.events) {
+      eventData = props.events[date] || false
+    } else {
+      eventData = false
+    }
+
+    if (!eventData) {
+      return []
+    } else if (eventData !== true) {
+      eventColors = arrayize(eventData)
+    } else if (typeof props.eventColor === 'string') {
+      eventColors = [props.eventColor]
+    } else if (typeof props.eventColor === 'function') {
+      eventColors = arrayize(props.eventColor(date))
+    } else if (Array.isArray(props.eventColor)) {
+      eventColors = props.eventColor
+    } else {
+      eventColors = arrayize(props.eventColor[date])
+    }
+
+    return eventColors.filter(Boolean)
+  }
+
+  function genEvents (date: string) {
+    const eventColors = getEventColors(date)
+
+    if (!eventColors.length) return null
+
+    return h('div', { class: 'v-date-picker-table__events' },
+      eventColors.map(color => h('div', setBackgroundColor(color))))
+  }
+
+  function genButton (value: string, isFloating: boolean, mouseEventType: string, formatter: DatePickerFormatter): VNode {
+    const isAllowed = isDateAllowed(value, props.min, props.max, props.allowedDates)
+    const isSelected = value === props.value || (Array.isArray(props.value) && props.value.indexOf(value) !== -1)
+    const isCurrent = value === props.current
+    const setColor = isSelected ? setBgColor : setTxtColor
+    const color = (isSelected || isCurrent) && (props.color || 'accent')
+
+    const onClick = () => {
+      if (props.disabled) return
+      if (isAllowed && !props.readonly) emit('input', value)
+      emit(`click:${mouseEventType}`, value)
+    }
+
+    const onDblclick = () => {
+      if (props.disabled) return
+      emit(`dblclick:${mouseEventType}`, value)
+    }
+
+    const data = setColor(color, {
+      class: ['v-btn', genButtonClasses(isAllowed, isFloating, isSelected, isCurrent)],
+      style: {},
+    })
+
+    return h('button', {
+      ...data,
+      type: 'button',
+      disabled: props.disabled || !isAllowed,
+      onClick,
+      onDblclick,
+    }, [
+      h('div', { class: 'v-btn__content' }, formatter(value)),
+      genEvents(value),
+    ])
+  }
+
+  function wheel (e: WheelEvent, calculateTableDate: CalculateTableDateFunction) {
+    e.preventDefault()
+    emit('tableDate', calculateTableDate(e.deltaY))
+  }
+
+  function touch (value: number, calculateTableDate: CalculateTableDateFunction) {
+    emit('tableDate', calculateTableDate(value))
+  }
+
+  function genTable (staticClass: string, children: VNodeArrayChildren, calculateTableDate: CalculateTableDateFunction) {
+    const transition = h(Transition, { name: computedTransition.value }, {
+      default: () => [h('table', { key: props.tableDate }, children)],
+    })
+
+    const node = h('div', {
+      class: [
+        staticClass,
+        {
+          'v-date-picker-table--disabled': props.disabled,
+        },
+        themeClasses.value,
+      ],
+      onWheel: (!props.disabled && props.scrollable) ? (e: WheelEvent) => wheel(e, calculateTableDate) : undefined,
+    }, [transition])
+
+    return withDirectives(node, [[Touch as any, {
+      left: (e: TouchWrapper) => (e.offsetX < -15) && touch(1, calculateTableDate),
+      right: (e: TouchWrapper) => (e.offsetX > 15) && touch(-1, calculateTableDate),
+    }]])
+  }
+
+  return {
+    displayedMonth,
+    displayedYear,
+    genButton,
+    genTable,
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite VEditDialog with defineComponent and reuse returnable/theme composables
- migrate VDatePicker plus its header and table subcomponents to the composition API
- introduce a shared useDatePickerTable composable to replace the date picker table mixin

## Testing
- not run (conversion only)

------
https://chatgpt.com/codex/tasks/task_e_68c83ad3fd6c8327b9309be22b5a81a7