### PR TITLE
refactor: migrate VWindow components to composition API

### DIFF
--- a/src/components/VItemGroup/VItemGroup.ts
+++ b/src/components/VItemGroup/VItemGroup.ts
@@ -133,6 +133,46 @@ export const BaseItemGroup = defineComponent({
       nextTick(updateItemsState)
     })
 
+    const proxy = vm?.proxy as any
+
+    if (proxy) {
+      Object.assign(proxy, {
+        getValue,
+        onClick,
+        register,
+        unregister,
+        updateItem,
+        updateItemsState,
+        updateInternalValue,
+        updateMandatory,
+        updateMultiple,
+        updateSingle,
+      })
+
+      Object.defineProperties(proxy, {
+        internalLazyValue: {
+          get: () => internalLazyValue.value,
+          set: (val) => { internalLazyValue.value = val }
+        },
+        internalValue: {
+          get: () => internalValue.value,
+          set: (val) => { internalValue.value = val }
+        },
+        items: {
+          get: () => items
+        },
+        selectedItems: {
+          get: () => selectedItems.value
+        },
+        selectedValues: {
+          get: () => selectedValues.value
+        },
+        toggleMethod: {
+          get: () => toggleMethod.value
+        }
+      })
+    }
+
     provide('itemGroup', { register, unregister, activeClass: props.activeClass })
 
     const classes = computed(() => ({


### PR DESCRIPTION
## Summary
- expose BaseItemGroup internals on the component instance so legacy extensions can keep working
- rewrite VWindow with defineComponent + setup, mirroring legacy methods and touch handling
- port VWindowItem to composables, wiring bootable/groupable state and keep a legacy render hook

## Testing
- not run (project has no automated tests yet)

------
https://chatgpt.com/codex/tasks/task_e_68c8402276f083278a1ebb3cf67ea6c9