### PR TITLE
refactor: convert time picker and timeline to composition api

### DIFF
--- a/src/components/VTimePicker/VTimePicker.ts
+++ b/src/components/VTimePicker/VTimePicker.ts
@@ -1,18 +1,20 @@
 // Components
 import VTimePickerTitle from './VTimePickerTitle'
 import VTimePickerClock from './VTimePickerClock'
+import VPicker from '../VPicker'
 
-// Mixins
-import Picker from '../../mixins/picker'
+// Composables
+import usePicker, { pickerProps } from '../../composables/usePicker'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
+import { colorProps } from '../../composables/useColorable'
 
 // Utils
 import { createRange } from '../../util/helpers'
 import pad from '../VDatePicker/util/pad'
-import mixins from '../../util/mixins'
 
 // Types
-import { VNode } from 'vue'
-import { PropValidator } from 'vue/types/options'
+import { defineComponent, computed, h, PropType, ref, watch } from 'vue'
+import type { VNode } from 'vue'
 
 const rangeHours24 = createRange(24)
 const rangeHours12am = createRange(12)
@@ -28,297 +30,305 @@ export { selectingTimes }
 
 type Period = 'am' | 'pm'
 
-export default mixins(
-  Picker
-/* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-time-picker',
 
   props: {
-    allowedHours: Function,
-    allowedMinutes: Function,
-    allowedSeconds: Function,
+    ...pickerProps,
+    ...themeProps,
+    ...colorProps,
+    allowedHours: Function as PropType<((value: number) => boolean) | undefined>,
+    allowedMinutes: Function as PropType<((value: number) => boolean) | undefined>,
+    allowedSeconds: Function as PropType<((value: number) => boolean) | undefined>,
     disabled: Boolean,
     format: {
-      type: String,
+      type: String as PropType<'ampm' | '24hr'>,
       default: 'ampm',
-      validator (val) {
-        return ['ampm', '24hr'].includes(val)
-      }
-    } as PropValidator<'ampm' | '24hr'>,
+      validator: (val: string) => ['ampm', '24hr'].includes(val),
+    },
     min: String,
     max: String,
     readonly: Boolean,
     scrollable: Boolean,
     useSeconds: Boolean,
-    value: null as any as PropValidator<any>
+    value: null as unknown as PropType<any>,
   },
 
-  data () {
-    return {
-      inputHour: null as number | null,
-      inputMinute: null as number | null,
-      inputSecond: null as number | null,
-      lazyInputHour: null as number | null,
-      lazyInputMinute: null as number | null,
-      lazyInputSecond: null as number | null,
-      period: 'am' as Period,
-      selecting: selectingTimes.hour as 1 | 2 | 3
-    }
-  },
+  emits: [
+    'change',
+    'click:hour',
+    'click:minute',
+    'click:second',
+    'input',
+  ],
 
-  computed: {
-    selectingHour: {
-      get () {
-        return this.selecting === selectingTimes.hour
-      },
-      set (v: boolean) {
-        this.selecting = selectingTimes.hour
-      }
-    },
-    selectingMinute: {
-      get () {
-        return this.selecting === selectingTimes.minute
-      },
-      set (v: boolean) {
-        this.selecting = selectingTimes.minute
-      }
-    },
-    selectingSecond: {
-      get () {
-        return this.selecting === selectingTimes.second
-      },
-      set (v: boolean) {
-        this.selecting = selectingTimes.second
-      }
-    },
-    isAllowedHourCb () {
-      if (!this.min && !this.max) return this.allowedHours
+  setup (props, { emit, slots }) {
+    const inputHour = ref<number | null>(null)
+    const inputMinute = ref<number | null>(null)
+    const inputSecond = ref<number | null>(null)
+    const lazyInputHour = ref<number | null>(null)
+    const lazyInputMinute = ref<number | null>(null)
+    const lazyInputSecond = ref<number | null>(null)
+    const period = ref<Period>('am')
+    const selecting = ref<1 | 2 | 3>(selectingTimes.hour)
 
-      const minHour = this.min ? Number(this.min.split(':')[0]) : 0
-      const maxHour = this.max ? Number(this.max.split(':')[0]) : 23
+    const clockRef = ref<InstanceType<typeof VTimePickerClock> | null>(null)
+
+    const { themeClasses } = useThemeable(props)
+    const { genPickerActionsSlot } = usePicker(props, { slots })
+
+    const isAmPm = computed(() => props.format === 'ampm')
+
+    const isAllowedHourCb = computed(() => {
+      if (!props.min && !props.max) return props.allowedHours
+
+      const minHour = props.min ? Number(props.min.split(':')[0]) : 0
+      const maxHour = props.max ? Number(props.max.split(':')[0]) : 23
 
       return (val: number) => {
-        return val >= minHour * 1 &&
-          val <= maxHour * 1 &&
-          (!this.allowedHours || this.allowedHours(val))
+        return val >= minHour &&
+          val <= maxHour &&
+          (!props.allowedHours || props.allowedHours(val))
       }
-    },
-    isAllowedMinuteCb () {
-      const isHourAllowed = !this.allowedHours || this.allowedHours(this.inputHour)
-      if (!this.min && !this.max) {
-        return isHourAllowed ? this.allowedMinutes : () => false
+    })
+
+    const isAllowedMinuteCb = computed(() => {
+      const isHourAllowed = !props.allowedHours || (inputHour.value != null && props.allowedHours(inputHour.value))
+      if (!props.min && !props.max) {
+        return isHourAllowed ? props.allowedMinutes : (() => false)
       }
 
-      const [minHour, minMinute] = this.min ? this.min.split(':').map(Number) : [0, 0]
-      const [maxHour, maxMinute] = this.max ? this.max.split(':').map(Number) : [23, 59]
-      const minTime = minHour * 60 + minMinute * 1
-      const maxTime = maxHour * 60 + maxMinute * 1
+      const [minHour, minMinute] = props.min ? props.min.split(':').map(Number) : [0, 0]
+      const [maxHour, maxMinute] = props.max ? props.max.split(':').map(Number) : [23, 59]
+      const minTime = minHour * 60 + minMinute
+      const maxTime = maxHour * 60 + maxMinute
 
       return (val: number) => {
-        const time = 60 * this.inputHour! + val
+        if (inputHour.value == null) return false
+
+        const time = 60 * inputHour.value + val
         return time >= minTime &&
           time <= maxTime &&
           isHourAllowed &&
-          (!this.allowedMinutes || this.allowedMinutes(val))
+          (!props.allowedMinutes || props.allowedMinutes(val))
       }
-    },
-    isAllowedSecondCb () {
-      const isHourAllowed = !this.allowedHours || this.allowedHours(this.inputHour)
-      const isMinuteAllowed = !this.allowedMinutes || this.allowedMinutes(this.inputMinute)
-      if (!this.min && !this.max) {
-        return isHourAllowed && isMinuteAllowed ? this.allowedSeconds : () => false
+    })
+
+    const isAllowedSecondCb = computed(() => {
+      const isHourAllowed = !props.allowedHours || (inputHour.value != null && props.allowedHours(inputHour.value))
+      const isMinuteAllowed = !props.allowedMinutes || (inputMinute.value != null && props.allowedMinutes(inputMinute.value))
+      if (!props.min && !props.max) {
+        return (isHourAllowed && isMinuteAllowed) ? props.allowedSeconds : (() => false)
       }
 
-      const [minHour, minMinute, minSecond] = this.min ? this.min.split(':').map(Number) : [0, 0, 0]
-      const [maxHour, maxMinute, maxSecond] = this.max ? this.max.split(':').map(Number) : [23, 59, 59]
-      const minTime = minHour * 3600 + minMinute * 60 + (minSecond || 0) * 1
-      const maxTime = maxHour * 3600 + maxMinute * 60 + (maxSecond || 0) * 1
+      const [minHour, minMinute, minSecond] = props.min ? props.min.split(':').map(Number) : [0, 0, 0]
+      const [maxHour, maxMinute, maxSecond] = props.max ? props.max.split(':').map(Number) : [23, 59, 59]
+      const minTime = minHour * 3600 + minMinute * 60 + (minSecond || 0)
+      const maxTime = maxHour * 3600 + maxMinute * 60 + (maxSecond || 0)
 
       return (val: number) => {
-        const time = 3600 * this.inputHour! + 60 * this.inputMinute! + val
+        if (inputHour.value == null || inputMinute.value == null) return false
+
+        const time = 3600 * inputHour.value + 60 * inputMinute.value + val
         return time >= minTime &&
           time <= maxTime &&
           isHourAllowed && isMinuteAllowed &&
-          (!this.allowedSeconds || this.allowedSeconds(val))
+          (!props.allowedSeconds || props.allowedSeconds(val))
       }
-    },
-    isAmPm () {
-      return this.format === 'ampm'
+    })
+
+    function convert24to12 (hour: number) {
+      return hour ? ((hour - 1) % 12 + 1) : 12
     }
-  },
 
-  watch: {
-    value: 'setInputData'
-  },
+    function convert12to24 (hour: number, newPeriod: Period) {
+      return hour % 12 + (newPeriod === 'pm' ? 12 : 0)
+    }
 
-  mounted () {
-    this.setInputData(this.value)
-  },
-
-  methods: {
-    genValue () {
-      if (this.inputHour != null && this.inputMinute != null && (!this.useSeconds || this.inputSecond != null)) {
-        return `${pad(this.inputHour)}:${pad(this.inputMinute)}` + (this.useSeconds ? `:${pad(this.inputSecond!)}` : '')
+    function genValue () {
+      if (inputHour.value != null && inputMinute.value != null && (!props.useSeconds || inputSecond.value != null)) {
+        return `${pad(inputHour.value)}:${pad(inputMinute.value)}` + (props.useSeconds ? `:${pad(inputSecond.value!)}` : '')
       }
 
       return null
-    },
-    emitValue () {
-      const value = this.genValue()
-      if (value !== null) this.$emit('input', value)
-    },
-    setPeriod (period: Period) {
-      this.period = period
-      if (this.inputHour != null) {
-        const newHour = this.inputHour! + (period === 'am' ? -12 : 12)
-        this.inputHour = this.firstAllowed('hour', newHour)
-        this.emitValue()
+    }
+
+    function emitValue () {
+      const value = genValue()
+      if (value !== null) emit('input', value)
+    }
+
+    function setPeriod (newPeriod: Period) {
+      period.value = newPeriod
+      if (inputHour.value != null) {
+        const newHour = inputHour.value + (newPeriod === 'am' ? -12 : 12)
+        inputHour.value = firstAllowed('hour', newHour)
+        emitValue()
       }
-    },
-    setInputData (value: string | null | Date) {
+    }
+
+    function setInputData (value: string | null | Date) {
       if (value == null || value === '') {
-        this.inputHour = null
-        this.inputMinute = null
-        this.inputSecond = null
+        inputHour.value = null
+        inputMinute.value = null
+        inputSecond.value = null
       } else if (value instanceof Date) {
-        this.inputHour = value.getHours()
-        this.inputMinute = value.getMinutes()
-        this.inputSecond = value.getSeconds()
+        inputHour.value = value.getHours()
+        inputMinute.value = value.getMinutes()
+        inputSecond.value = value.getSeconds()
       } else {
-        const [, hour, minute, , second, period] = value.trim().toLowerCase().match(/^(\d+):(\d+)(:(\d+))?([ap]m)?$/) || new Array(6)
+        const match = (value.trim().toLowerCase().match(/^(\d+):(\d+)(:(\d+))?([ap]m)?$/) || new Array(6)) as string[]
+        const [, hour, minute, , second, periodMatch] = match
 
-        this.inputHour = period ? this.convert12to24(parseInt(hour, 10), period as Period) : parseInt(hour, 10)
-        this.inputMinute = parseInt(minute, 10)
-        this.inputSecond = parseInt(second || 0, 10)
+        const parsedHour = parseInt(hour, 10)
+        inputHour.value = periodMatch ? convert12to24(parsedHour, periodMatch as Period) : parsedHour
+        inputMinute.value = parseInt(minute, 10)
+        inputSecond.value = parseInt((second || '0'), 10)
       }
 
-      this.period = (this.inputHour == null || this.inputHour < 12) ? 'am' : 'pm'
-    },
-    convert24to12 (hour: number) {
-      return hour ? ((hour - 1) % 12 + 1) : 12
-    },
-    convert12to24 (hour: number, period: Period) {
-      return hour % 12 + (period === 'pm' ? 12 : 0)
-    },
-    onInput (value: number) {
-      if (this.selecting === selectingTimes.hour) {
-        this.inputHour = this.isAmPm ? this.convert12to24(value, this.period) : value
-      } else if (this.selecting === selectingTimes.minute) {
-        this.inputMinute = value
+      period.value = (inputHour.value == null || inputHour.value < 12) ? 'am' : 'pm'
+    }
+
+    function onInput (value: number) {
+      if (selecting.value === selectingTimes.hour) {
+        inputHour.value = isAmPm.value ? convert12to24(value, period.value) : value
+      } else if (selecting.value === selectingTimes.minute) {
+        inputMinute.value = value
       } else {
-        this.inputSecond = value
+        inputSecond.value = value
       }
-      this.emitValue()
-    },
-    onChange (value: number) {
-      this.$emit(`click:${selectingNames[this.selecting]}`, value)
+      emitValue()
+    }
 
-      const emitChange = this.selecting === (this.useSeconds ? selectingTimes.second : selectingTimes.minute)
+    function onChange (value: number) {
+      emit(`click:${selectingNames[selecting.value]}`, value)
 
-      if (this.selecting === selectingTimes.hour) {
-        this.selecting = selectingTimes.minute
-      } else if (this.useSeconds && this.selecting === selectingTimes.minute) {
-        this.selecting = selectingTimes.second
+      const emitChange = selecting.value === (props.useSeconds ? selectingTimes.second : selectingTimes.minute)
+
+      if (selecting.value === selectingTimes.hour) {
+        selecting.value = selectingTimes.minute
+      } else if (props.useSeconds && selecting.value === selectingTimes.minute) {
+        selecting.value = selectingTimes.second
       }
 
-      if (this.inputHour === this.lazyInputHour &&
-        this.inputMinute === this.lazyInputMinute &&
-        (!this.useSeconds || this.inputSecond === this.lazyInputSecond)
+      if (inputHour.value === lazyInputHour.value &&
+        inputMinute.value === lazyInputMinute.value &&
+        (!props.useSeconds || inputSecond.value === lazyInputSecond.value)
       ) return
 
-      const time = this.genValue()
+      const time = genValue()
       if (time === null) return
 
-      this.lazyInputHour = this.inputHour
-      this.lazyInputMinute = this.inputMinute
-      this.useSeconds && (this.lazyInputSecond = this.inputSecond)
+      lazyInputHour.value = inputHour.value
+      lazyInputMinute.value = inputMinute.value
+      if (props.useSeconds) lazyInputSecond.value = inputSecond.value
 
-      emitChange && this.$emit('change', time)
-    },
-    firstAllowed (type: 'hour' | 'minute' | 'second', value: number) {
-      const allowedFn = type === 'hour' ? this.isAllowedHourCb : (type === 'minute' ? this.isAllowedMinuteCb : this.isAllowedSecondCb)
+      if (emitChange) emit('change', time)
+    }
+
+    function firstAllowed (type: 'hour' | 'minute' | 'second', value: number) {
+      const allowedFn = type === 'hour'
+        ? isAllowedHourCb.value
+        : type === 'minute'
+          ? isAllowedMinuteCb.value
+          : isAllowedSecondCb.value
+
       if (!allowedFn) return value
 
-      // TODO: clean up
       const range = type === 'minute'
         ? range60
-        : (type === 'second'
+        : type === 'second'
           ? range60
-          : (this.isAmPm
-            ? (value < 12
-              ? rangeHours12am
-              : rangeHours12pm)
-            : rangeHours24))
+          : (isAmPm.value
+            ? (value < 12 ? rangeHours12am : rangeHours12pm)
+            : rangeHours24)
       const first = range.find(v => allowedFn((v + value) % range.length + range[0]))
       return ((first || 0) + value) % range.length + range[0]
-    },
-    genClock () {
-      return this.$createElement(VTimePickerClock, {
-        props: {
-          allowedValues:
-            this.selecting === selectingTimes.hour
-              ? this.isAllowedHourCb
-              : (this.selecting === selectingTimes.minute
-                ? this.isAllowedMinuteCb
-                : this.isAllowedSecondCb),
-          color: this.color,
-          dark: this.dark,
-          disabled: this.disabled,
-          double: this.selecting === selectingTimes.hour && !this.isAmPm,
-          format: this.selecting === selectingTimes.hour
-            ? (this.isAmPm ? this.convert24to12 : (val: number) => val)
-            : (val: number) => pad(val, 2),
-          light: this.light,
-          max: this.selecting === selectingTimes.hour ? (this.isAmPm && this.period === 'am' ? 11 : 23) : 59,
-          min: this.selecting === selectingTimes.hour && this.isAmPm && this.period === 'pm' ? 12 : 0,
-          readonly: this.readonly,
-          scrollable: this.scrollable,
-          size: Number(this.width) - ((!this.fullWidth && this.landscape) ? 80 : 20),
-          step: this.selecting === selectingTimes.hour ? 1 : 5,
-          value: this.selecting === selectingTimes.hour
-            ? this.inputHour
-            : (this.selecting === selectingTimes.minute
-              ? this.inputMinute
-              : this.inputSecond)
-        },
-        on: {
-          input: this.onInput,
-          change: this.onChange
-        },
-        ref: 'clock'
-      })
-    },
-    genPickerBody () {
-      return this.$createElement('div', {
-        staticClass: 'v-time-picker-clock__container',
-        key: this.selecting
-      }, [this.genClock()])
-    },
-    genPickerTitle () {
-      return this.$createElement(VTimePickerTitle, {
-        props: {
-          ampm: this.isAmPm,
-          disabled: this.disabled,
-          hour: this.inputHour,
-          minute: this.inputMinute,
-          second: this.inputSecond,
-          period: this.period,
-          readonly: this.readonly,
-          useSeconds: this.useSeconds,
-          selecting: this.selecting
-        },
-        on: {
-          'update:selecting': (value: 1 | 2 | 3) => (this.selecting = value),
-          'update:period': this.setPeriod
-        },
-        ref: 'title',
-        slot: 'title'
+    }
+
+    function genClock (): VNode {
+      return h(VTimePickerClock, {
+        allowedValues:
+          selecting.value === selectingTimes.hour
+            ? isAllowedHourCb.value
+            : (selecting.value === selectingTimes.minute
+              ? isAllowedMinuteCb.value
+              : isAllowedSecondCb.value),
+        color: props.color,
+        dark: props.dark,
+        disabled: props.disabled,
+        double: selecting.value === selectingTimes.hour && !isAmPm.value,
+        format: selecting.value === selectingTimes.hour
+          ? (isAmPm.value ? convert24to12 : (val: number) => val)
+          : (val: number) => pad(val, 2),
+        light: props.light,
+        max: selecting.value === selectingTimes.hour ? (isAmPm.value && period.value === 'am' ? 11 : 23) : 59,
+        min: selecting.value === selectingTimes.hour && isAmPm.value && period.value === 'pm' ? 12 : 0,
+        readonly: props.readonly,
+        scrollable: props.scrollable,
+        size: Number(props.width) - ((!props.fullWidth && props.landscape) ? 80 : 20),
+        step: selecting.value === selectingTimes.hour ? 1 : 5,
+        value: selecting.value === selectingTimes.hour
+          ? inputHour.value
+          : (selecting.value === selectingTimes.minute
+            ? inputMinute.value
+            : inputSecond.value),
+        ref: clockRef,
+        onInput: onInput,
+        onChange: onChange,
       })
     }
-  },
 
-  render (): VNode {
-    return this.genPicker('v-picker--time')
+    function genPickerBody () {
+      return h('div', {
+        class: 'v-time-picker-clock__container',
+        key: selecting.value,
+      }, [genClock()])
+    }
+
+    function genPickerTitle () {
+      return h(VTimePickerTitle, {
+        ampm: isAmPm.value,
+        disabled: props.disabled,
+        hour: inputHour.value,
+        minute: inputMinute.value,
+        second: inputSecond.value,
+        period: period.value,
+        readonly: props.readonly,
+        useSeconds: props.useSeconds,
+        selecting: selecting.value,
+        ['onUpdate:selecting']: (value: 1 | 2 | 3) => (selecting.value = value),
+        ['onUpdate:period']: setPeriod,
+      })
+    }
+
+    watch(() => props.value, value => {
+      setInputData(value as any)
+    }, { immediate: true })
+
+    return () => {
+      const pickerSlots: Record<string, () => VNode | VNode[] | null | undefined> = {}
+
+      if (!props.noTitle) {
+        const title = genPickerTitle()
+        if (title) pickerSlots.title = () => title
+      }
+
+      const body = genPickerBody()
+      if (body) pickerSlots.default = () => body
+
+      const actions = genPickerActionsSlot()
+      if (actions) pickerSlots.actions = () => actions
+
+      return h(VPicker, {
+        class: ['v-picker--time', themeClasses.value],
+        color: props.headerColor || props.color,
+        dark: props.dark,
+        fullWidth: props.fullWidth,
+        landscape: props.landscape,
+        light: props.light,
+        width: props.width,
+      }, pickerSlots)
+    }
   }
 })

--- a/src/components/VTimePicker/VTimePickerClock.ts
+++ b/src/components/VTimePicker/VTimePickerClock.ts
@@ -1,265 +1,271 @@
 import "@/css/vuetify.css"
 
-// Mixins
-import Colorable from '../../mixins/colorable'
-import Themeable from '../../mixins/themeable'
-import mixins, { ExtractVue } from '../../util/mixins'
-import Vue, { VNode } from 'vue'
+// Composables
+import useColorable, { colorProps } from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
+
+// Types
+import { defineComponent, computed, h, PropType, ref, watch } from 'vue'
+import type { VNode } from 'vue'
 
 interface Point {
   x: number
   y: number
 }
 
-interface options extends Vue {
-  $refs: {
-    clock: HTMLElement
-    innerClock: HTMLElement
-  }
-}
-
-export default mixins<options &
-/* eslint-disable indent */
-  ExtractVue<[
-    typeof Colorable,
-    typeof Themeable
-  ]>
-/* eslint-enable indent */
->(
-  Colorable,
-  Themeable
-/* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-time-picker-clock',
 
   props: {
-    allowedValues: Function,
+    ...colorProps,
+    ...themeProps,
+    allowedValues: Function as PropType<((value: number) => boolean) | undefined>,
     disabled: Boolean,
     double: Boolean,
     format: {
-      type: Function,
-      default: (val: string | number) => val
+      type: Function as PropType<(val: string | number) => string | number>,
+      default: (val: string | number) => val,
     },
     max: {
       type: Number,
-      required: true
+      required: true,
     },
     min: {
       type: Number,
-      required: true
+      required: true,
     },
     scrollable: Boolean,
     readonly: Boolean,
     rotate: {
       type: Number,
-      default: 0
+      default: 0,
     },
     step: {
       type: Number,
-      default: 1
+      default: 1,
     },
-    value: Number
+    value: Number,
   },
 
-  data () {
-    return {
-      inputValue: this.value,
-      isDragging: false,
-      valueOnMouseDown: null as number | null,
-      valueOnMouseUp: null as number | null
-    }
-  },
+  emits: ['change', 'input'],
 
-  computed: {
-    count (): number {
-      return this.max - this.min + 1
-    },
-    degreesPerUnit (): number {
-      return 360 / this.roundCount
-    },
-    degrees (): number {
-      return this.degreesPerUnit * Math.PI / 180
-    },
-    displayedValue (): number {
-      return this.value == null ? this.min : this.value
-    },
-    innerRadiusScale (): number {
-      return 0.62
-    },
-    roundCount (): number {
-      return this.double ? (this.count / 2) : this.count
-    }
-  },
+  setup (props, { emit }) {
+    const clock = ref<HTMLElement | null>(null)
+    const innerClock = ref<HTMLElement | null>(null)
 
-  watch: {
-    value (value) {
-      this.inputValue = value
-    }
-  },
+    const inputValue = ref<number | null>(props.value ?? null)
+    const isDragging = ref(false)
+    const valueOnMouseDown = ref<number | null>(null)
+    const valueOnMouseUp = ref<number | null>(null)
 
-  methods: {
-    wheel (e: WheelEvent) {
+    const { setBackgroundColor } = useColorable(props)
+    const { themeClasses } = useThemeable(props)
+
+    const count = computed(() => props.max - props.min + 1)
+    const roundCount = computed(() => props.double ? (count.value / 2) : count.value)
+    const degreesPerUnit = computed(() => 360 / roundCount.value)
+    const degrees = computed(() => degreesPerUnit.value * Math.PI / 180)
+    const displayedValue = computed(() => props.value == null ? props.min : props.value)
+    const innerRadiusScale = computed(() => 0.62)
+
+    function wheel (e: WheelEvent) {
       e.preventDefault()
 
       const delta = Math.sign(-e.deltaY || 1)
-      let value = this.displayedValue
+      let value = displayedValue.value
       do {
         value = value + delta
-        value = (value - this.min + this.count) % this.count + this.min
-      } while (!this.isAllowed(value) && value !== this.displayedValue)
+        value = (value - props.min + count.value) % count.value + props.min
+      } while (!isAllowed(value) && value !== displayedValue.value)
 
-      if (value !== this.displayedValue) {
-        this.update(value)
+      if (value !== displayedValue.value) {
+        update(value)
       }
-    },
-    isInner (value: number) {
-      return this.double && (value - this.min >= this.roundCount)
-    },
-    handScale (value: number) {
-      return this.isInner(value) ? this.innerRadiusScale : 1
-    },
-    isAllowed (value: number) {
-      return !this.allowedValues || this.allowedValues(value)
-    },
-    genValues () {
+    }
+
+    function isInner (value: number) {
+      return props.double && (value - props.min >= roundCount.value)
+    }
+
+    function handScale (value: number) {
+      return isInner(value) ? innerRadiusScale.value : 1
+    }
+
+    function isAllowed (value: number) {
+      return !props.allowedValues || props.allowedValues(value)
+    }
+
+    function genValues () {
       const children: VNode[] = []
 
-      for (let value = this.min; value <= this.max; value = value + this.step) {
-        const color = value === this.value && (this.color || 'accent')
-        children.push(this.$createElement('span', this.setBackgroundColor(color, {
-          staticClass: 'v-time-picker-clock__item',
-          'class': {
-            'v-time-picker-clock__item--active': value === this.displayedValue,
-            'v-time-picker-clock__item--disabled': this.disabled || !this.isAllowed(value)
+      for (let value = props.min; value <= props.max; value = value + props.step) {
+        const color = value === props.value && (props.color || 'accent')
+        const data = setBackgroundColor(color, {
+          class: {
+            'v-time-picker-clock__item': true,
+            'v-time-picker-clock__item--active': value === displayedValue.value,
+            'v-time-picker-clock__item--disabled': props.disabled || !isAllowed(value),
           },
-          style: this.getTransform(value),
-          domProps: { innerHTML: `<span>${this.format(value)}</span>` }
-        })))
+          style: getTransform(value),
+        })
+
+        children.push(h('span', {
+          class: data.class,
+          style: data.style,
+          innerHTML: `<span>${props.format!(value)}</span>`,
+        }))
       }
 
       return children
-    },
-    genHand () {
-      const scale = `scaleY(${this.handScale(this.displayedValue)})`
-      const angle = this.rotate + this.degreesPerUnit * (this.displayedValue - this.min)
-      const color = (this.value != null) && (this.color || 'accent')
-      return this.$createElement('div', this.setBackgroundColor(color, {
-        staticClass: 'v-time-picker-clock__hand',
-        'class': {
-          'v-time-picker-clock__hand--inner': this.isInner(this.value)
+    }
+
+    function genHand () {
+      const scale = `scaleY(${handScale(displayedValue.value)})`
+      const angle = props.rotate + degreesPerUnit.value * (displayedValue.value - props.min)
+      const color = (props.value != null) && (props.color || 'accent')
+      const data = setBackgroundColor(color, {
+        class: {
+          'v-time-picker-clock__hand': true,
+          'v-time-picker-clock__hand--inner': isInner(props.value as number),
         },
         style: {
-          transform: `rotate(${angle}deg) ${scale}`
-        }
-      }))
-    },
-    getTransform (i: number) {
-      const { x, y } = this.getPosition(i)
+          transform: `rotate(${angle}deg) ${scale}`,
+        },
+      })
+
+      return h('div', {
+        class: data.class,
+        style: data.style,
+      })
+    }
+
+    function getTransform (i: number) {
+      const { x, y } = getPosition(i)
       return {
         left: `${50 + x * 50}%`,
-        top: `${50 + y * 50}%`
+        top: `${50 + y * 50}%`,
       }
-    },
-    getPosition (value: number) {
-      const rotateRadians = this.rotate * Math.PI / 180
+    }
+
+    function getPosition (value: number) {
+      const rotateRadians = props.rotate * Math.PI / 180
       return {
-        x: Math.sin((value - this.min) * this.degrees + rotateRadians) * this.handScale(value),
-        y: -Math.cos((value - this.min) * this.degrees + rotateRadians) * this.handScale(value)
+        x: Math.sin((value - props.min) * degrees.value + rotateRadians) * handScale(value),
+        y: -Math.cos((value - props.min) * degrees.value + rotateRadians) * handScale(value),
       }
-    },
-    onMouseDown (e: MouseEvent | TouchEvent) {
+    }
+
+    function onMouseDown (e: MouseEvent | TouchEvent) {
       e.preventDefault()
 
-      this.valueOnMouseDown = null
-      this.valueOnMouseUp = null
-      this.isDragging = true
-      this.onDragMove(e)
-    },
-    onMouseUp () {
-      this.isDragging = false
-      if (this.valueOnMouseUp !== null && this.isAllowed(this.valueOnMouseUp)) {
-        this.$emit('change', this.valueOnMouseUp)
-      }
-    },
-    onDragMove (e: MouseEvent | TouchEvent) {
-      e.preventDefault()
-      if (!this.isDragging && e.type !== 'click') return
+      valueOnMouseDown.value = null
+      valueOnMouseUp.value = null
+      isDragging.value = true
+      onDragMove(e)
+    }
 
-      const { width, top, left } = this.$refs.clock.getBoundingClientRect()
-      const { width: innerWidth } = this.$refs.innerClock.getBoundingClientRect()
+    function onMouseUp () {
+      isDragging.value = false
+      if (valueOnMouseUp.value !== null && isAllowed(valueOnMouseUp.value)) {
+        emit('change', valueOnMouseUp.value)
+      }
+    }
+
+    function onDragMove (e: MouseEvent | TouchEvent) {
+      e.preventDefault()
+      if (!isDragging.value && e.type !== 'click') return
+
+      const clockEl = clock.value
+      const innerClockEl = innerClock.value
+      if (!clockEl || !innerClockEl) return
+
+      const { width, top, left } = clockEl.getBoundingClientRect()
+      const { width: innerWidth } = innerClockEl.getBoundingClientRect()
       const { clientX, clientY } = 'touches' in e ? e.touches[0] : e
       const center = { x: width / 2, y: -width / 2 }
       const coords = { x: clientX - left, y: top - clientY }
-      const handAngle = Math.round(this.angle(center, coords) - this.rotate + 360) % 360
-      const insideClick = this.double && this.euclidean(center, coords) < (innerWidth + innerWidth * this.innerRadiusScale) / 4
+      const handAngle = Math.round(angle(center, coords) - props.rotate + 360) % 360
+      const insideClick = props.double && euclidean(center, coords) < (innerWidth + innerWidth * innerRadiusScale.value) / 4
       const value = (
-        Math.round(handAngle / this.degreesPerUnit) +
-        (insideClick ? this.roundCount : 0)
-      ) % this.count + this.min
+        Math.round(handAngle / degreesPerUnit.value) +
+        (insideClick ? roundCount.value : 0)
+      ) % count.value + props.min
 
       // Necessary to fix edge case when selecting left part of the value(s) at 12 o'clock
       let newValue: number
-      if (handAngle >= (360 - this.degreesPerUnit / 2)) {
-        newValue = insideClick ? this.max - this.roundCount + 1 : this.min
+      if (handAngle >= (360 - degreesPerUnit.value / 2)) {
+        newValue = insideClick ? props.max - roundCount.value + 1 : props.min
       } else {
         newValue = value
       }
 
-      if (this.isAllowed(value)) {
-        if (this.valueOnMouseDown === null) {
-          this.valueOnMouseDown = newValue
+      if (isAllowed(value)) {
+        if (valueOnMouseDown.value === null) {
+          valueOnMouseDown.value = newValue
         }
-        this.valueOnMouseUp = newValue
-        this.update(newValue)
+        valueOnMouseUp.value = newValue
+        update(newValue)
       }
-    },
-    update (value: number) {
-      if (this.inputValue !== value) {
-        this.inputValue = value
-        this.$emit('input', value)
+    }
+
+    function update (value: number) {
+      if (inputValue.value !== value) {
+        inputValue.value = value
+        emit('input', value)
       }
-    },
-    euclidean (p0: Point, p1: Point) {
+    }
+
+    function euclidean (p0: Point, p1: Point) {
       const dx = p1.x - p0.x
       const dy = p1.y - p0.y
 
       return Math.sqrt(dx * dx + dy * dy)
-    },
-    angle (center: Point, p1: Point) {
-      const value = 2 * Math.atan2(p1.y - center.y - this.euclidean(center, p1), p1.x - center.x)
+    }
+
+    function angle (center: Point, p1: Point) {
+      const value = 2 * Math.atan2(p1.y - center.y - euclidean(center, p1), p1.x - center.x)
       return Math.abs(value * 180 / Math.PI)
     }
-  },
 
-  render (h): VNode {
-    const data = {
-      staticClass: 'v-time-picker-clock',
-      class: {
-        'v-time-picker-clock--indeterminate': this.value == null,
-        ...this.themeClasses
-      },
-      on: (this.readonly || this.disabled) ? undefined : Object.assign({
-        mousedown: this.onMouseDown,
-        mouseup: this.onMouseUp,
-        mouseleave: () => (this.isDragging && this.onMouseUp()),
-        touchstart: this.onMouseDown,
-        touchend: this.onMouseUp,
-        mousemove: this.onDragMove,
-        touchmove: this.onDragMove
-      }, this.scrollable ? {
-        wheel: this.wheel
-      } : {}),
-      ref: 'clock'
-    }
+    watch(() => props.value, value => {
+      inputValue.value = value ?? null
+    })
 
-    return h('div', data, [
-      h('div', {
-        staticClass: 'v-time-picker-clock__inner',
-        ref: 'innerClock'
+    return () => {
+      const listeners = (props.readonly || props.disabled)
+        ? {}
+        : {
+            onMousedown: onMouseDown,
+            onMouseup: onMouseUp,
+            onMouseleave: () => { if (isDragging.value) onMouseUp() },
+            onTouchstart: onMouseDown,
+            onTouchend: onMouseUp,
+            onMousemove: onDragMove,
+            onTouchmove: onDragMove,
+          }
+
+      const scrollListeners = props.scrollable && !(props.readonly || props.disabled)
+        ? { onWheel: wheel }
+        : {}
+
+      return h('div', {
+        class: [{
+          'v-time-picker-clock': true,
+          'v-time-picker-clock--indeterminate': props.value == null,
+          ...themeClasses.value,
+        }],
+        ref: clock,
+        ...listeners,
+        ...scrollListeners,
       }, [
-        this.genHand(),
-        this.genValues()
+        h('div', {
+          class: 'v-time-picker-clock__inner',
+          ref: innerClock,
+        }, [
+          genHand(),
+          genValues(),
+        ]),
       ])
-    ])
+    }
   }
 })

--- a/src/components/VTimePicker/VTimePickerTitle.ts
+++ b/src/components/VTimePicker/VTimePickerTitle.ts
@@ -1,78 +1,80 @@
 import "@/css/vuetify.css"
 
-// Mixins
-import PickerButton from '../../mixins/picker-button'
+// Composables
+import usePickerButton, { pickerButtonProps } from '../../composables/usePickerButton'
 
 // Utils
 import { pad } from '../VDatePicker/util'
-import mixins from '../../util/mixins'
 
 import { selectingTimes } from './VTimePicker'
-import { PropValidator } from 'vue/types/options'
-import { VNode } from 'vue'
 
-export default mixins(
-  PickerButton
-/* @vue/component */
-).extend({
+// Types
+import { defineComponent, h, PropType } from 'vue'
+
+export default defineComponent({
   name: 'v-time-picker-title',
 
   props: {
+    ...pickerButtonProps,
     ampm: Boolean,
     disabled: Boolean,
     hour: Number,
     minute: Number,
     second: Number,
     period: {
-      type: String,
-      validator: period => period === 'am' || period === 'pm'
-    } as PropValidator<'am' | 'pm'>,
+      type: String as PropType<'am' | 'pm'>,
+      validator: period => period === 'am' || period === 'pm',
+    },
     readonly: Boolean,
     useSeconds: Boolean,
-    selecting: Number
+    selecting: Number,
   },
 
-  methods: {
-    genTime () {
-      let hour = this.hour
-      if (this.ampm) {
+  setup (props, { emit }) {
+    const { genPickerButton } = usePickerButton(props, { emit })
+
+    function genTime () {
+      let hour = props.hour
+      if (props.ampm) {
         hour = hour ? ((hour - 1) % 12 + 1) : 12
       }
 
-      const displayedHour = this.hour == null ? '--' : this.ampm ? String(hour) : pad(hour)
-      const displayedMinute = this.minute == null ? '--' : pad(this.minute)
+      const displayedHour = props.hour == null ? '--' : props.ampm ? String(hour) : pad(hour)
+      const displayedMinute = props.minute == null ? '--' : pad(props.minute)
       const titleContent = [
-        this.genPickerButton('selecting', selectingTimes.hour, displayedHour, this.disabled),
-        this.$createElement('span', ':'),
-        this.genPickerButton('selecting', selectingTimes.minute, displayedMinute, this.disabled)
+        genPickerButton('selecting', selectingTimes.hour, displayedHour, props.disabled),
+        h('span', ':'),
+        genPickerButton('selecting', selectingTimes.minute, displayedMinute, props.disabled),
       ]
 
-      if (this.useSeconds) {
-        const displayedSecond = this.second == null ? '--' : pad(this.second)
-        titleContent.push(this.$createElement('span', ':'))
-        titleContent.push(this.genPickerButton('selecting', selectingTimes.second, displayedSecond, this.disabled))
+      if (props.useSeconds) {
+        const displayedSecond = props.second == null ? '--' : pad(props.second)
+        titleContent.push(h('span', ':'))
+        titleContent.push(genPickerButton('selecting', selectingTimes.second, displayedSecond, props.disabled))
       }
-      return this.$createElement('div', {
-        'class': 'v-time-picker-title__time'
+
+      return h('div', {
+        class: 'v-time-picker-title__time',
       }, titleContent)
-    },
-    genAmPm () {
-      return this.$createElement('div', {
-        staticClass: 'v-time-picker-title__ampm'
+    }
+
+    function genAmPm () {
+      return h('div', {
+        class: 'v-time-picker-title__ampm',
       }, [
-        this.genPickerButton('period', 'am', 'am', this.disabled || this.readonly),
-        this.genPickerButton('period', 'pm', 'pm', this.disabled || this.readonly)
+        genPickerButton('period', 'am', 'am', props.disabled || props.readonly),
+        genPickerButton('period', 'pm', 'pm', props.disabled || props.readonly),
       ])
     }
-  },
 
-  render (h): VNode {
-    const children = [this.genTime()]
+    return () => {
+      const children = [genTime()]
 
-    this.ampm && children.push(this.genAmPm())
+      if (props.ampm) children.push(genAmPm())
 
-    return h('div', {
-      staticClass: 'v-time-picker-title'
-    }, children)
+      return h('div', {
+        class: 'v-time-picker-title',
+      }, children)
+    }
   }
 })

--- a/src/components/VTimeline/VTimeline.ts
+++ b/src/components/VTimeline/VTimeline.ts
@@ -1,38 +1,32 @@
 // Styles
 import "@/css/vuetify.css"
 
+// Composables
+import useThemeable, { themeProps } from '../../composables/useThemeable'
+
 // Types
-import { VNode } from 'vue'
-import mixins from '../../util/mixins'
+import { defineComponent, computed, h } from 'vue'
 
-// Mixins
-import Themeable from '../../mixins/themeable'
-
-export default mixins(
-  Themeable
-/* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-timeline',
 
   props: {
+    ...themeProps,
     alignTop: Boolean,
-    dense: Boolean
+    dense: Boolean,
   },
 
-  computed: {
-    classes (): {} {
-      return {
-        'v-timeline--align-top': this.alignTop,
-        'v-timeline--dense': this.dense,
-        ...this.themeClasses
-      }
-    }
-  },
+  setup (props, { slots }) {
+    const { themeClasses } = useThemeable(props)
 
-  render (h): VNode {
-    return h('div', {
-      staticClass: 'v-timeline',
-      'class': this.classes
-    }, this.$slots.default)
+    const classes = computed(() => ({
+      'v-timeline--align-top': props.alignTop,
+      'v-timeline--dense': props.dense,
+      ...themeClasses.value,
+    }))
+
+    return () => h('div', {
+      class: ['v-timeline', classes.value],
+    }, slots.default?.())
   }
 })

--- a/src/components/VTimeline/VTimelineItem.ts
+++ b/src/components/VTimeline/VTimelineItem.ts
@@ -1,25 +1,20 @@
-// Types
-import mixins from '../../util/mixins'
-import { VNode, VNodeData } from 'vue'
-
 // Components
 import VIcon from '../VIcon'
 
-// Mixins
-import Themeable from '../../mixins/themeable'
-import Colorable from '../../mixins/colorable'
+// Composables
+import useColorable from '../../composables/useColorable'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
-export default mixins(
-  Colorable,
-  Themeable
-/* @vue/component */
-).extend({
+// Types
+import { defineComponent, computed, h } from 'vue'
+
+export default defineComponent({
   name: 'v-timeline-item',
 
   props: {
     color: {
       type: String,
-      default: 'primary'
+      default: 'primary',
     },
     fillDot: Boolean,
     hideDot: Boolean,
@@ -28,72 +23,73 @@ export default mixins(
     large: Boolean,
     left: Boolean,
     right: Boolean,
-    small: Boolean
+    small: Boolean,
+    ...themeProps,
   },
 
-  computed: {
-    hasIcon (): boolean {
-      return !!this.icon || !!this.$slots.icon
+  setup (props, { slots }) {
+    const { setBackgroundColor } = useColorable(props)
+    const { themeClasses, isDark } = useThemeable(props)
+
+    const hasIcon = computed(() => !!props.icon || !!slots.icon)
+
+    function genBody () {
+      return h('div', { class: 'v-timeline-item__body' }, slots.default?.())
     }
-  },
 
-  methods: {
-    genBody () {
-      return this.$createElement('div', {
-        staticClass: 'v-timeline-item__body'
-      }, this.$slots.default)
-    },
-    genIcon (): VNode | VNode[] {
-      if (this.$slots.icon) {
-        return this.$slots.icon
+    function genIcon () {
+      const slotIcon = slots.icon?.()
+      if (slotIcon) {
+        return slotIcon
       }
 
-      return this.$createElement(VIcon, {
-        props: {
-          color: this.iconColor,
-          dark: !this.theme.isDark,
-          small: this.small
-        }
-      }, this.icon)
-    },
-    genInnerDot () {
-      const data: VNodeData = this.setBackgroundColor(this.color)
+      return h(VIcon, {
+        color: props.iconColor,
+        dark: !isDark.value,
+        small: props.small,
+      }, () => props.icon)
+    }
 
-      return this.$createElement('div', {
-        staticClass: 'v-timeline-item__inner-dot',
-        ...data
-      }, [this.hasIcon && this.genIcon()])
-    },
-    genDot () {
-      return this.$createElement('div', {
-        staticClass: 'v-timeline-item__dot',
+    function genInnerDot () {
+      const data = setBackgroundColor(props.color, {})
+
+      return h('div', {
+        class: ['v-timeline-item__inner-dot', data.class],
+        style: data.style,
+      }, hasIcon.value ? genIcon() : undefined)
+    }
+
+    function genDot () {
+      return h('div', {
         class: {
-          'v-timeline-item__dot--small': this.small,
-          'v-timeline-item__dot--large': this.large
-        }
-      }, [this.genInnerDot()])
-    },
-    genOpposite () {
-      return this.$createElement('div', {
-        staticClass: 'v-timeline-item__opposite'
-      }, this.$slots.opposite)
+          'v-timeline-item__dot': true,
+          'v-timeline-item__dot--small': props.small,
+          'v-timeline-item__dot--large': props.large,
+        },
+      }, [genInnerDot()])
     }
-  },
 
-  render (h): VNode {
-    const children = [this.genBody()]
+    function genOpposite () {
+      return h('div', {
+        class: 'v-timeline-item__opposite',
+      }, slots.opposite?.())
+    }
 
-    if (!this.hideDot) children.unshift(this.genDot())
-    if (this.$slots.opposite) children.push(this.genOpposite())
+    return () => {
+      const children = [genBody()]
 
-    return h('div', {
-      staticClass: 'v-timeline-item',
-      class: {
-        'v-timeline-item--fill-dot': this.fillDot,
-        'v-timeline-item--left': this.left,
-        'v-timeline-item--right': this.right,
-        ...this.themeClasses
-      }
-    }, children)
+      if (!props.hideDot) children.unshift(genDot())
+      if (slots.opposite) children.push(genOpposite())
+
+      return h('div', {
+        class: {
+          'v-timeline-item': true,
+          'v-timeline-item--fill-dot': props.fillDot,
+          'v-timeline-item--left': props.left,
+          'v-timeline-item--right': props.right,
+          ...themeClasses.value,
+        },
+      }, children)
+    }
   }
 })


### PR DESCRIPTION
## Summary
- migrate the time picker components to `defineComponent`, using the picker, color, and theme composables
- rewrite the timeline components with the composition API and theme composable support
- replace mixins with composables and update render logic for all touched components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8401e7b0083278335463ce709c699