### PR TITLE
refactor: convert snackbar sparkline speed dial stepper

### DIFF
--- a/src/components/VStepper/VStepper.ts
+++ b/src/components/VStepper/VStepper.ts
@@ -1,114 +1,129 @@
-// Styles
-import "@/css/vuetify.css"
+import '@/css/vuetify.css'
 
-// Components
 import VStepperStep from './VStepperStep'
 import VStepperContent from './VStepperContent'
 
-// Mixins
-import { provide as RegistrableProvide } from '../../mixins/registrable'
-import Themeable from '../../mixins/themeable'
+import useRegistrableProvide from '../../composables/useRegistrableProvide'
+import useThemeable, { themeProps } from '../../composables/useThemeable'
 
-// Util
-import mixins from '../../util/mixins'
+import { defineComponent, h, ref, computed, watch, nextTick, onMounted, provide } from 'vue'
 
-// Types
-import { VNode } from 'vue'
+export type VStepperStepInstance = InstanceType<typeof VStepperStep>
+export type VStepperContentInstance = InstanceType<typeof VStepperContent>
 
-type VStepperStepInstance = InstanceType<typeof VStepperStep>
-type VStepperContentInstance = InstanceType<typeof VStepperContent>
-
-export default mixins(
-  RegistrableProvide('stepper'),
-  Themeable
-/* @vue/component */
-).extend({
+export default defineComponent({
   name: 'v-stepper',
 
-  provide (): object {
-    return {
-      stepClick: this.stepClick,
-      isVertical: this.vertical
-    }
-  },
-
   props: {
+    ...themeProps,
     nonLinear: Boolean,
     altLabels: Boolean,
     vertical: Boolean,
     value: [Number, String]
   },
 
-  data () {
-    return {
-      inputValue: null as any,
-      isBooted: false,
-      steps: [] as VStepperStepInstance[],
-      content: [] as VStepperContentInstance[],
-      isReverse: false
+  setup (props, { slots, attrs, emit }) {
+    const { themeClasses } = useThemeable(props)
+    const { register: baseRegister, unregister: baseUnregister } = useRegistrableProvide('stepper')
+
+    const steps: VStepperStepInstance[] = []
+    const content: VStepperContentInstance[] = []
+
+    const inputValue = ref<any>(null)
+    const isBooted = ref(false)
+    const isReverse = ref(false)
+
+    function stepClick (step: string | number) {
+      nextTick(() => { inputValue.value = step })
     }
-  },
 
-  computed: {
-    classes (): object {
-      return {
-        'v-stepper': true,
-        'v-stepper--is-booted': this.isBooted,
-        'v-stepper--vertical': this.vertical,
-        'v-stepper--alt-labels': this.altLabels,
-        'v-stepper--non-linear': this.nonLinear,
-        ...this.themeClasses
+    function register (item: any) {
+      baseRegister(item)
+
+      const name = item && item.$options ? item.$options.name : undefined
+
+      if (name === 'v-stepper-step') {
+        if (!steps.includes(item)) steps.push(item as VStepperStepInstance)
+        if (inputValue.value !== null && typeof item.toggle === 'function') {
+          item.toggle(inputValue.value)
+        }
+      } else if (name === 'v-stepper-content') {
+        if (!content.includes(item)) content.push(item as VStepperContentInstance)
+        if (typeof item.setVertical === 'function') item.setVertical(props.vertical)
+        if (inputValue.value !== null && typeof item.toggle === 'function') {
+          item.toggle(inputValue.value, isReverse.value)
+        }
       }
     }
-  },
 
-  watch: {
-    inputValue (val, prev) {
-      this.isReverse = Number(val) < Number(prev)
-      for (let index = this.steps.length; --index >= 0;) {
-        this.steps[index].toggle(this.inputValue)
-      }
-      for (let index = this.content.length; --index >= 0;) {
-        this.content[index].toggle(this.inputValue, this.isReverse)
+    function unregister (item: any) {
+      const name = item && item.$options ? item.$options.name : undefined
+
+      if (name === 'v-stepper-step') {
+        const index = steps.indexOf(item as VStepperStepInstance)
+        if (index > -1) steps.splice(index, 1)
+      } else if (name === 'v-stepper-content') {
+        const index = content.indexOf(item as VStepperContentInstance)
+        if (index > -1) content.splice(index, 1)
       }
 
-      this.$emit('input', this.inputValue)
-      prev && (this.isBooted = true)
-    },
-    value () {
-      this.$nextTick(() => (this.inputValue = this.value))
+      baseUnregister(item)
     }
-  },
 
-  mounted () {
-    this.inputValue = this.value || this.steps[0].step || 1
-  },
+    provide('stepper', { register, unregister })
+    provide('stepClick', stepClick)
+    provide('isVertical', computed(() => props.vertical))
 
-  methods: {
-    register (item: VStepperStepInstance | VStepperContentInstance) {
-      if (item.$options.name === 'v-stepper-step') {
-        this.steps.push(item as VStepperStepInstance)
-      } else if (item.$options.name === 'v-stepper-content') {
-        (item as VStepperContentInstance).isVertical = this.vertical
-        this.content.push(item as VStepperContentInstance)
+    const classes = computed(() => ({
+      'v-stepper--is-booted': isBooted.value,
+      'v-stepper--vertical': props.vertical,
+      'v-stepper--alt-labels': props.altLabels,
+      'v-stepper--non-linear': props.nonLinear,
+      ...themeClasses.value
+    }))
+
+    watch(inputValue, (val, prev) => {
+      isReverse.value = Number(val) < Number(prev)
+
+      for (let index = steps.length - 1; index >= 0; index--) {
+        const step = steps[index]
+        step && typeof step.toggle === 'function' && step.toggle(val)
       }
-    },
-    unregister (item: VStepperStepInstance | VStepperContentInstance) {
-      if (item.$options.name === 'v-stepper-step') {
-        this.steps = this.steps.filter((i: VStepperStepInstance) => i !== item)
-      } else if (item.$options.name === 'v-stepper-content') {
-        (item as VStepperContentInstance).isVertical = this.vertical
-        this.content = this.content.filter((i: VStepperContentInstance) => i !== item)
+
+      for (let index = content.length - 1; index >= 0; index--) {
+        const item = content[index]
+        item && typeof item.toggle === 'function' && item.toggle(val, isReverse.value)
       }
-    },
-    stepClick (step: string | number) {
-      this.$nextTick(() => (this.inputValue = step))
+
+      emit('input', val)
+      if (prev) isBooted.value = true
+    })
+
+    watch(() => props.value, val => {
+      nextTick(() => { inputValue.value = val })
+    })
+
+    watch(() => props.vertical, val => {
+      for (let index = content.length - 1; index >= 0; index--) {
+        const item = content[index]
+        if (typeof item.setVertical === 'function') item.setVertical(val)
+      }
+    })
+
+    onMounted(() => {
+      inputValue.value = props.value != null
+        ? props.value
+        : steps[0] && (steps[0] as any).step || 1
+    })
+
+    return () => {
+      const { class: classAttr, style, ...restAttrs } = attrs as any
+
+      return h('div', {
+        class: ['v-stepper', classes.value, classAttr],
+        style,
+        ...restAttrs
+      }, slots.default?.())
     }
-  },
-
-  render (h): VNode {
-    return h('div', {
-      'class': this.classes
-    }, this.$slots.default)
   }
 })


### PR DESCRIPTION
## Summary
- rewrite VSnackbar with the Composition API, replacing mixins with colorable, toggleable, and positionable composables
- migrate VSparkline helpers into setup() with Composition API state and render helpers
- convert VSpeedDial to defineComponent and composables, handling hover/activator logic in setup()
- refactor VStepper and VStepperContent to provide registration via composables and expose toggle utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84019d8bc8327aa2d4f3521de2283