### PR TITLE
Refactor navigation drawer and picker family to Composition API

### DIFF
--- a/src/components/VBottomNav/VBottomNav.ts
+++ b/src/components/VBottomNav/VBottomNav.ts
@@ -35,7 +35,8 @@ export default defineComponent({
     useButtonGroup(props)
 
     const computedHeight = computed(() => parseInt(props.height as any))
-    useApplicationable(props, computed(() => props.value ? computedHeight.value : 0), ['height', 'value'])
+    const { setUpdateApplication } = useApplicationable(props, 'bottom', ['height', 'value'])
+    setUpdateApplication(() => props.value ? computedHeight.value : 0)
 
     const classes = computed(() => ({
       'v-bottom-nav--absolute': props.absolute,


### PR DESCRIPTION
## Summary
- migrate VNavigationDrawer to use defineComponent and composables for application layout, overlay handling, and navigation state
- convert VOverflowBtn, VPagination, VParallax, and VPicker to setup-based Composition API implementations
- enhance useApplicationable so components can supply custom layout updates and update VBottomNav to use it

## Testing
- not run (conversion only)

------
https://chatgpt.com/codex/tasks/task_e_68c84014ddd8832796169f25a7f519f8