### PR TITLE
refactor: switch calendar/date-picker mixins to composables

### DIFF
--- a/src/components/VCalendar/mixins/calendar-base.ts
+++ b/src/components/VCalendar/mixins/calendar-base.ts
@@ -1,89 +1,28 @@
+import { defineComponent } from 'vue'
 
-// Mixins
-import mixins from '../../../util/mixins'
-import Themeable from '../../../mixins/themeable'
-import Colorable from '../../../mixins/colorable'
-import Times from './times'
-import Mouse from './mouse'
+// Composables
+import useCalendarBase from '../../../composables/useCalendarBase'
 
 // Util
 import props from '../util/props'
-import {
-  VTimestamp,
-  VTimestampFormatter,
-  parseTimestamp,
-  getWeekdaySkips,
-  createDayList,
-  createNativeLocaleFormatter,
-  getStartOfWeek,
-  getEndOfWeek
-} from '../util/timestamp'
+import { validateTimestamp } from '../util/timestamp'
 
-/* @vue/component */
-export default mixins(Colorable, Themeable, Times, Mouse).extend({
+export default defineComponent({
   name: 'calendar-base',
 
-  props: props.base,
-
-  computed: {
-    weekdaySkips (): number[] {
-      return getWeekdaySkips(this.weekdays)
+  props: {
+    ...props.base,
+    now: {
+      type: String,
+      validator: validateTimestamp,
     },
-    parsedStart (): VTimestamp {
-      return parseTimestamp(this.start) as VTimestamp
-    },
-    parsedEnd (): VTimestamp {
-      return parseTimestamp(this.end) as VTimestamp
-    },
-    days (): VTimestamp[] {
-      return createDayList(
-        this.parsedStart,
-        this.parsedEnd,
-        this.times.today,
-        this.weekdaySkips
-      )
-    },
-    dayFormatter (): VTimestampFormatter {
-      if (this.dayFormat) {
-        return this.dayFormat as VTimestampFormatter
-      }
-
-      const options = { timeZone: 'UTC', day: 'numeric' }
-
-      return createNativeLocaleFormatter(
-        this.locale,
-        (_tms, _short) => options
-      )
-    },
-    weekdayFormatter (): VTimestampFormatter {
-      if (this.weekdayFormat) {
-        return this.weekdayFormat as VTimestampFormatter
-      }
-
-      const longOptions = { timeZone: 'UTC', weekday: 'long' }
-      const shortOptions = { timeZone: 'UTC', weekday: 'short' }
-
-      return createNativeLocaleFormatter(
-        this.locale,
-        (_tms, short) => short ? shortOptions : longOptions
-      )
-    }
   },
 
-  methods: {
-    getRelativeClasses (timestamp: VTimestamp, outside = false): object {
-      return {
-        'v-present': timestamp.present,
-        'v-past': timestamp.past,
-        'v-future': timestamp.future,
-        'v-outside': outside
-      }
-    },
-    getStartOfWeek (timestamp: VTimestamp): VTimestamp {
-      return getStartOfWeek(timestamp, this.weekdays, this.times.today)
-    },
-    getEndOfWeek (timestamp: VTimestamp): VTimestamp {
-      return getEndOfWeek(timestamp, this.weekdays, this.times.today)
+  setup (props, { emit }) {
+    const calendar = useCalendarBase(props, { emit })
+
+    return {
+      ...calendar,
     }
-  }
+  },
 })

--- a/src/components/VCalendar/mixins/calendar-with-intervals.ts
+++ b/src/components/VCalendar/mixins/calendar-with-intervals.ts
@@ -1,146 +1,27 @@
+import { defineComponent, ref } from 'vue'
 
-// Mixins
-import CalendarBase from './calendar-base'
+// Composables
+import useCalendarWithIntervals from '../../../composables/useCalendarWithIntervals'
 
 // Util
 import props from '../util/props'
-import {
-  VTimestamp,
-  VTime,
-  VTimestampFormatter,
-  parseTime,
-  copyTimestamp,
-  updateMinutes,
-  createDayList,
-  createIntervalList,
-  createNativeLocaleFormatter
-} from '../util/timestamp'
 
-/* @vue/component */
-export default CalendarBase.extend({
+export default defineComponent({
   name: 'calendar-with-intervals',
 
-  props: props.intervals,
-
-  computed: {
-    parsedFirstInterval (): number {
-      return parseInt(this.firstInterval)
-    },
-    parsedIntervalMinutes (): number {
-      return parseInt(this.intervalMinutes)
-    },
-    parsedIntervalCount (): number {
-      return parseInt(this.intervalCount)
-    },
-    parsedIntervalHeight (): number {
-      return parseFloat(this.intervalHeight)
-    },
-    firstMinute (): number {
-      return this.parsedFirstInterval * this.parsedIntervalMinutes
-    },
-    bodyHeight (): number {
-      return this.parsedIntervalCount * this.parsedIntervalHeight
-    },
-    days (): VTimestamp[] {
-      return createDayList(
-        this.parsedStart,
-        this.parsedEnd,
-        this.times.today,
-        this.weekdaySkips,
-        this.maxDays
-      )
-    },
-    intervals (): VTimestamp[][] {
-      const days: VTimestamp[] = this.days
-      const first: number = this.parsedFirstInterval
-      const minutes: number = this.parsedIntervalMinutes
-      const count: number = this.parsedIntervalCount
-      const now: VTimestamp = this.times.now
-
-      return days.map(d => createIntervalList(d, first, minutes, count, now))
-    },
-    intervalFormatter (): VTimestampFormatter {
-      if (this.intervalFormat) {
-        return this.intervalFormat as VTimestampFormatter
-      }
-
-      const longOptions = { timeZone: 'UTC', hour12: true, hour: '2-digit', minute: '2-digit' }
-      const shortOptions = { timeZone: 'UTC', hour12: true, hour: 'numeric', minute: '2-digit' }
-      const shortHourOptions = { timeZone: 'UTC', hour12: true, hour: 'numeric' }
-
-      return createNativeLocaleFormatter(
-        this.locale,
-        (tms, short) => short ? (tms.minute === 0 ? shortHourOptions : shortOptions) : longOptions
-      )
-    }
+  props: {
+    ...props.base,
+    ...props.intervals,
   },
 
-  methods: {
-    showIntervalLabelDefault (interval: VTimestamp): boolean {
-      const first: VTimestamp = this.intervals[0][0]
-      const isFirst: boolean = first.hour === interval.hour && first.minute === interval.minute
-      return !isFirst && interval.minute === 0
-    },
-    intervalStyleDefault (_interval: VTimestamp): object | undefined {
-      return undefined
-    },
-    getTimestampAtEvent (e: MouseEvent | TouchEvent, day: VTimestamp): VTimestamp {
-      const timestamp: VTimestamp = copyTimestamp(day)
-      const bounds = (e.currentTarget as HTMLElement).getBoundingClientRect()
-      const baseMinutes: number = this.firstMinute
-      const touchEvent: TouchEvent = e as TouchEvent
-      const mouseEvent: MouseEvent = e as MouseEvent
-      const touches: TouchList = touchEvent.changedTouches || touchEvent.touches
-      const clientY: number = touches && touches[0] ? touches[0].clientY : mouseEvent.clientY
-      const addIntervals: number = (clientY - bounds.top) / this.parsedIntervalHeight
-      const addMinutes: number = Math.floor(addIntervals * this.parsedIntervalMinutes)
-      const minutes: number = baseMinutes + addMinutes
+  setup (props, { emit }) {
+    const scrollArea = ref<HTMLElement>()
 
-      return updateMinutes(timestamp, minutes, this.times.now)
-    },
-    getSlotScope (timestamp: VTimestamp): any {
-      const scope = copyTimestamp(timestamp) as any
-      scope.timeToY = this.timeToY
-      scope.minutesToPixels = this.minutesToPixels
-      return scope
-    },
-    scrollToTime (time: VTime): boolean {
-      const y = this.timeToY(time)
-      const pane = this.$refs.scrollArea as HTMLElement
+    const calendar = useCalendarWithIntervals(props, { emit, refs: { scrollArea } })
 
-      if (y === false || !pane) {
-        return false
-      }
-
-      pane.scrollTop = y
-
-      return true
-    },
-    minutesToPixels (minutes: number): number {
-      return minutes / this.parsedIntervalMinutes * this.parsedIntervalHeight
-    },
-    timeToY (time: VTime, clamp = true): number | false {
-      const minutes = parseTime(time)
-
-      if (minutes === false) {
-        return false
-      }
-
-      const min: number = this.firstMinute
-      const gap: number = this.parsedIntervalCount * this.parsedIntervalMinutes
-      const delta: number = (minutes - min) / gap
-      let y: number = delta * this.bodyHeight
-
-      if (clamp) {
-        if (y < 0) {
-          y = 0
-        }
-        if (y > this.bodyHeight) {
-          y = this.bodyHeight
-        }
-      }
-
-      return y
+    return {
+      scrollArea,
+      ...calendar,
     }
-  }
+  },
 })

--- a/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -1,198 +1,20 @@
-import "@/css/vuetify.css"
+import { defineComponent } from 'vue'
 
-// Directives
-import Touch, { TouchWrapper } from '../../../directives/touch'
+// Composables
+import useDatePickerTable, { datePickerTableProps } from '../../../composables/useDatePickerTable'
 
-// Mixins
-import Colorable from '../../../mixins/colorable'
-import Themeable from '../../../mixins/themeable'
-
-// Utils
-import isDateAllowed, { AllowedDateFunction } from '../util/isDateAllowed'
-import mixins from '../../../util/mixins'
-
-// Types
-import { VNodeChildren } from 'vue'
-import { PropValidator } from 'vue/types/options'
-import { DatePickerFormatter } from '../util/createNativeLocaleFormatter'
-import { DateEvents, DateEventColors, DateEventColorValue } from '../VDatePicker'
-
-type CalculateTableDateFunction = (v: number) => string
-
-export default mixins(
-  Colorable,
-  Themeable
-/* @vue/component */
-).extend({
-  directives: { Touch },
+export default defineComponent({
+  name: 'date-picker-table',
 
   props: {
-    allowedDates: Function as PropValidator<AllowedDateFunction | undefined>,
-    current: String,
-    disabled: Boolean,
-    format: Function as PropValidator<DatePickerFormatter | undefined>,
-    events: {
-      type: [Array, Function, Object],
-      default: () => null
-    } as any as PropValidator<DateEvents>,
-    eventColor: {
-      type: [Array, Function, Object, String],
-      default: () => 'warning'
-    } as any as PropValidator<DateEventColors>,
-    locale: {
-      type: String,
-      default: 'en-us'
-    },
-    min: String,
-    max: String,
-    readonly: Boolean,
-    scrollable: Boolean,
-    tableDate: {
-      type: String,
-      required: true
-    },
-    value: [String, Array]
+    ...datePickerTableProps,
   },
 
-  data: () => ({
-    isReversing: false
-  }),
+  setup (props, { emit }) {
+    const table = useDatePickerTable(props, emit)
 
-  computed: {
-    computedTransition (): string {
-      return (this.isReversing === !this.$vuetify.rtl) ? 'tab-reverse-transition' : 'tab-transition'
-    },
-    displayedMonth (): number {
-      return Number(this.tableDate.split('-')[1]) - 1
-    },
-    displayedYear (): number {
-      return Number(this.tableDate.split('-')[0])
+    return {
+      ...table,
     }
   },
-
-  watch: {
-    tableDate (newVal: string, oldVal: string) {
-      this.isReversing = newVal < oldVal
-    }
-  },
-
-  methods: {
-    genButtonClasses (isAllowed: boolean, isFloating: boolean, isSelected: boolean, isCurrent: boolean) {
-      return {
-        'v-btn--active': isSelected,
-        'v-btn--flat': !isSelected,
-        'v-btn--icon': isSelected && isAllowed && isFloating,
-        'v-btn--floating': isFloating,
-        'v-btn--depressed': !isFloating && isSelected,
-        'v-btn--disabled': !isAllowed || (this.disabled && isSelected),
-        'v-btn--outline': isCurrent && !isSelected,
-        ...this.themeClasses
-      }
-    },
-    genButtonEvents (value: string, isAllowed: boolean, mouseEventType: string) {
-      if (this.disabled) return undefined
-
-      return {
-        click: () => {
-          isAllowed && !this.readonly && this.$emit('input', value)
-          this.$emit(`click:${mouseEventType}`, value)
-        },
-        dblclick: () => this.$emit(`dblclick:${mouseEventType}`, value)
-      }
-    },
-    genButton (value: string, isFloating: boolean, mouseEventType: string, formatter: DatePickerFormatter) {
-      const isAllowed = isDateAllowed(value, this.min, this.max, this.allowedDates)
-      const isSelected = value === this.value || (Array.isArray(this.value) && this.value.indexOf(value) !== -1)
-      const isCurrent = value === this.current
-      const setColor = isSelected ? this.setBackgroundColor : this.setTextColor
-      const color = (isSelected || isCurrent) && (this.color || 'accent')
-
-      return this.$createElement('button', setColor(color, {
-        staticClass: 'v-btn',
-        'class': this.genButtonClasses(isAllowed, isFloating, isSelected, isCurrent),
-        attrs: {
-          type: 'button'
-        },
-        domProps: {
-          disabled: this.disabled || !isAllowed
-        },
-        on: this.genButtonEvents(value, isAllowed, mouseEventType)
-      }), [
-        this.$createElement('div', {
-          staticClass: 'v-btn__content'
-        }, [formatter(value)]),
-        this.genEvents(value)
-      ])
-    },
-    getEventColors (date: string) {
-      const arrayize = (v: string | string[]) => Array.isArray(v) ? v : [v]
-      let eventData: boolean | DateEventColorValue
-      let eventColors: string[] = []
-
-      if (Array.isArray(this.events)) {
-        eventData = this.events.includes(date)
-      } else if (this.events instanceof Function) {
-        eventData = this.events(date) || false
-      } else if (this.events) {
-        eventData = this.events[date] || false
-      } else {
-        eventData = false
-      }
-
-      if (!eventData) {
-        return []
-      } else if (eventData !== true) {
-        eventColors = arrayize(eventData)
-      } else if (typeof this.eventColor === 'string') {
-        eventColors = [this.eventColor]
-      } else if (typeof this.eventColor === 'function') {
-        eventColors = arrayize(this.eventColor(date))
-      } else if (Array.isArray(this.eventColor)) {
-        eventColors = this.eventColor
-      } else {
-        eventColors = arrayize(this.eventColor[date])
-      }
-
-      return eventColors.filter(v => v)
-    },
-    genEvents (date: string) {
-      const eventColors = this.getEventColors(date)
-
-      return eventColors.length ? this.$createElement('div', {
-        staticClass: 'v-date-picker-table__events'
-      }, eventColors.map(color => this.$createElement('div', this.setBackgroundColor(color)))) : null
-    },
-    wheel (e: WheelEvent, calculateTableDate: CalculateTableDateFunction) {
-      e.preventDefault()
-      this.$emit('tableDate', calculateTableDate(e.deltaY))
-    },
-    touch (value: number, calculateTableDate: CalculateTableDateFunction) {
-      this.$emit('tableDate', calculateTableDate(value))
-    },
-    genTable (staticClass: string, children: VNodeChildren, calculateTableDate: CalculateTableDateFunction) {
-      const transition = this.$createElement('transition', {
-        props: { name: this.computedTransition }
-      }, [this.$createElement('table', { key: this.tableDate }, children)])
-
-      const touchDirective = {
-        name: 'touch',
-        value: {
-          left: (e: TouchWrapper) => (e.offsetX < -15) && this.touch(1, calculateTableDate),
-          right: (e: TouchWrapper) => (e.offsetX > 15) && this.touch(-1, calculateTableDate)
-        }
-      }
-
-      return this.$createElement('div', {
-        staticClass,
-        class: {
-          'v-date-picker-table--disabled': this.disabled,
-          ...this.themeClasses
-        },
-        on: (!this.disabled && this.scrollable) ? {
-          wheel: (e: WheelEvent) => this.wheel(e, calculateTableDate)
-        } : undefined,
-        directives: [touchDirective]
-      }, [transition])
-    }
-  }
 })

--- a/src/composables/useDatePickerTable.ts
+++ b/src/composables/useDatePickerTable.ts
@@ -4,7 +4,7 @@ import { computed, getCurrentInstance, h, ref, watch, withDirectives, Transition
 import Touch, { TouchWrapper } from '../directives/touch'
 
 // Composables
-import useColorable, { colorProps, setBackgroundColor } from './useColorable'
+import useColorable, { colorProps } from './useColorable'
 import useThemeable, { themeProps } from './useThemeable'
 
 // Utils
@@ -51,7 +51,7 @@ export const datePickerTableProps = {
 
 export default function useDatePickerTable (props: any, emit: EmitFn) {
   const { themeClasses } = useThemeable(props)
-  const { setBackgroundColor: setBgColor, setTextColor: setTxtColor } = useColorable(props)
+  const { setBackgroundColor, setTextColor } = useColorable(props)
 
   const vm = getCurrentInstance()
   const isRtl = computed(() => Boolean(vm?.proxy?.$vuetify?.rtl))
@@ -133,7 +133,7 @@ export default function useDatePickerTable (props: any, emit: EmitFn) {
     const isAllowed = isDateAllowed(value, props.min, props.max, props.allowedDates)
     const isSelected = value === props.value || (Array.isArray(props.value) && props.value.indexOf(value) !== -1)
     const isCurrent = value === props.current
-    const setColor = isSelected ? setBgColor : setTxtColor
+    const setColor = isSelected ? setBackgroundColor : setTextColor
     const color = (isSelected || isCurrent) && (props.color || 'accent')
 
     const onClick = () => {
@@ -196,9 +196,19 @@ export default function useDatePickerTable (props: any, emit: EmitFn) {
   }
 
   return {
+    themeClasses,
+    setBackgroundColor,
+    setTextColor,
+    isReversing,
+    computedTransition,
     displayedMonth,
     displayedYear,
+    genButtonClasses,
+    getEventColors,
+    genEvents,
     genButton,
+    wheel,
+    touch,
     genTable,
   }
 }


### PR DESCRIPTION
## Summary
- replace the legacy calendar-base mixin with a composition API wrapper around `useCalendarBase`, including support for the optional `now` prop
- update the calendar-with-intervals mixin to delegate to `useCalendarWithIntervals` and expose the scroll area ref expected by consumers
- convert the date-picker table mixin to reuse `useDatePickerTable` and expand that composable to expose the functionality the mixin previously provided

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c84fa860b88327be5f579a2c8018c2