### PR TITLE
Refine VCalendar composable typings

### DIFF
--- a/src/components/VCalendar/composables/useCalendarBase.ts
+++ b/src/components/VCalendar/composables/useCalendarBase.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue'
 import useColorable from '../../../composables/useColorable'
 import useThemeable from '../../../composables/useThemeable'
 import useTimes from './useTimes'
-import useMouse from './useMouse'
+import useMouse, { type EmitFn } from './useMouse'
 import {
   VTimestamp,
   VTimestampFormatter,
@@ -14,7 +14,12 @@ import {
   getEndOfWeek
 } from '../util/timestamp'
 
-export default function useCalendarBase (props: any, { emit }) {
+export interface CalendarBaseContext {
+  emit: EmitFn
+}
+
+export default function useCalendarBase (props: any, context: CalendarBaseContext) {
+  const { emit } = context
   const { setTextColor } = useColorable(props)
   const { themeClasses } = useThemeable(props)
   const { times } = useTimes(props)

--- a/src/components/VCalendar/composables/useCalendarWithIntervals.ts
+++ b/src/components/VCalendar/composables/useCalendarWithIntervals.ts
@@ -1,5 +1,6 @@
-import { computed } from 'vue'
-import useCalendarBase from './useCalendarBase'
+import { computed, isRef } from 'vue'
+import type { Ref } from 'vue'
+import useCalendarBase, { type CalendarBaseContext } from './useCalendarBase'
 import {
   VTimestamp,
   VTime,
@@ -12,7 +13,13 @@ import {
   createNativeLocaleFormatter
 } from '../util/timestamp'
 
-export default function useCalendarWithIntervals (props: any, context: any) {
+export interface CalendarWithIntervalsContext extends CalendarBaseContext {
+  refs?: {
+    scrollArea?: Ref<HTMLElement | undefined> | HTMLElement
+  }
+}
+
+export default function useCalendarWithIntervals (props: any, context: CalendarWithIntervalsContext) {
   const base = useCalendarBase(props, context)
 
   const parsedFirstInterval = computed(() => parseInt(props.firstInterval))
@@ -81,8 +88,8 @@ export default function useCalendarWithIntervals (props: any, context: any) {
 
   function scrollToTime (time: VTime): boolean {
     const y = timeToY(time)
-    const refOrEl: any = context.refs?.scrollArea
-    const pane: HTMLElement | undefined = refOrEl && 'value' in refOrEl ? refOrEl.value : refOrEl
+    const refOrEl = context.refs?.scrollArea
+    const pane: HTMLElement | undefined = refOrEl ? (isRef(refOrEl) ? refOrEl.value : refOrEl) : undefined
     if (y === false || !pane) return false
     pane.scrollTop = y
     return true

--- a/src/components/VCalendar/composables/useMouse.ts
+++ b/src/components/VCalendar/composables/useMouse.ts
@@ -1,5 +1,7 @@
 export type MouseHandler = (e: MouseEvent | TouchEvent) => any
 
+export type EmitFn = (event: string, ...args: any[]) => void
+
 export type MouseEvents = {
   [event: string]: {
     event: string
@@ -17,7 +19,7 @@ export type MouseEventsMap = {
   [event: string]: MouseHandler | MouseHandler[]
 }
 
-export default function useMouse (emit: (e: string, value?: any) => void) {
+export default function useMouse (emit: EmitFn) {
   function getMouseEventHandlers (events: MouseEvents, getEvent: MouseHandler): MouseEventsMap {
     const on: MouseEventsMap = {}
 


### PR DESCRIPTION
## Summary
- define and share typing for calendar composable emit contexts
- tighten the mouse helper signature and reuse it across composables
- handle scroll area references safely when scrolling to a time slot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c96eaa7c548327ace2936fb72e9ff9