### PR TITLE
Fix options composable import path

### DIFF
--- a/src/components/Vuetify/composables/useOptions.ts
+++ b/src/components/Vuetify/composables/useOptions.ts
@@ -1,4 +1,4 @@
-import { VuetifyOptions } from '../../../../types'
+import { VuetifyOptions } from '../../../types'
 
 const OPTIONS_DEFAULTS = {
   minifyTheme: null,


### PR DESCRIPTION
## Summary
- update useOptions composable to import VuetifyOptions from the src/types barrel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c96ea251048327a865cfffc0aad9ce