### PR TITLE
refactor: export calendar components

### DIFF
--- a/src/components/VBtnToggle/VBtnToggle.ts
+++ b/src/components/VBtnToggle/VBtnToggle.ts
@@ -7,7 +7,7 @@ import useButtonGroup from '../../composables/useButtonGroup'
 // Types
 import { defineComponent, h, computed } from 'vue'
 
-export default defineComponent({
+export const VBtnToggle = defineComponent({
   name: 'v-btn-toggle',
 
   props: {
@@ -29,4 +29,6 @@ export default defineComponent({
     return () => h('div', { class: classes.value }, slots.default?.())
   }
 })
+
+export default VBtnToggle
 

--- a/src/components/VCalendar/VCalendar.ts
+++ b/src/components/VCalendar/VCalendar.ts
@@ -39,7 +39,7 @@ const calendarProps = {
   ...props.calendar
 }
 
-export default defineComponent({
+export const VCalendar = defineComponent({
   name: 'v-calendar',
 
   props: calendarProps,
@@ -188,4 +188,6 @@ export default defineComponent({
     }
   }
 })
+
+export default VCalendar
 

--- a/src/components/VCalendar/VCalendarDaily.ts
+++ b/src/components/VCalendar/VCalendarDaily.ts
@@ -18,7 +18,7 @@ const dailyProps = {
   ...props.intervals
 }
 
-export default defineComponent({
+export const VCalendarDaily = defineComponent({
   name: 'v-calendar-daily',
 
   directives: { Resize },
@@ -46,4 +46,6 @@ export default defineComponent({
     }, slots.default?.())
   }
 })
+
+export default VCalendarDaily
 

--- a/src/components/VCalendar/VCalendarMonthly.ts
+++ b/src/components/VCalendar/VCalendarMonthly.ts
@@ -16,7 +16,7 @@ const monthlyProps = {
   ...props.weeks
 }
 
-export default defineComponent({
+export const VCalendarMonthly = defineComponent({
   name: 'v-calendar-monthly',
 
   props: monthlyProps,
@@ -32,4 +32,6 @@ export default defineComponent({
     }, slots)
   }
 })
+
+export default VCalendarMonthly
 

--- a/src/components/VCalendar/VCalendarWeekly.ts
+++ b/src/components/VCalendar/VCalendarWeekly.ts
@@ -15,7 +15,7 @@ const weeklyProps = {
   ...props.weeks
 }
 
-export default defineComponent({
+export const VCalendarWeekly = defineComponent({
   name: 'v-calendar-weekly',
 
   props: weeklyProps,
@@ -33,4 +33,6 @@ export default defineComponent({
     return () => h('div', { class: classes.value }, slots.default?.())
   }
 })
+
+export default VCalendarWeekly
 


### PR DESCRIPTION
## Summary
- expose VBtnToggle and calendar components as named defineComponent exports while retaining default exports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c974dbb8548327afe8493bbf3d67d7