### PR TITLE
refactor: move rating and select slider state into setup

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -22,7 +22,7 @@ import { camelize, getPropertyFromItem, keyCodes } from '../../util/helpers'
 import { consoleError, consoleWarn } from '../../util/console'
 
 // Types
-import { defineComponent } from 'vue'
+import { defineComponent, reactive, ref, watch } from 'vue'
 
 export const defaultMenuProps = {
   closeOnClick: false,
@@ -101,31 +101,43 @@ export default defineComponent({
     const { valueComparator } = useComparable(props)
     const { noDataText } = useFilterable(props)
 
+    const attrsInput = reactive({ role: 'combobox' })
+    const cachedItems = ref(props.cacheItems ? props.items.slice() : [])
+    const content = ref(null)
+    const isBooted = ref(false)
+    const isMenuActive = ref(false)
+    const lastItem = ref(20)
+    const lazyValue = ref(props.value !== undefined
+      ? props.value
+      : props.multiple ? [] : undefined)
+    const selectedIndex = ref(-1)
+    const selectedItems = ref([])
+    const keyboardLookupPrefix = ref('')
+    const keyboardLookupLastTime = ref(0)
+
+    watch(() => props.value, val => {
+      lazyValue.value = val !== undefined
+        ? val
+        : (props.multiple ? [] : undefined)
+    })
+
     return {
       setTextColor,
       valueComparator,
-      noDataText
+      noDataText,
+      attrsInput,
+      cachedItems,
+      content,
+      isBooted,
+      isMenuActive,
+      lastItem,
+      lazyValue,
+      selectedIndex,
+      selectedItems,
+      keyboardLookupPrefix,
+      keyboardLookupLastTime
     }
   },
-
-  data: vm => ({
-    attrsInput: { role: 'combobox' },
-    cachedItems: vm.cacheItems ? vm.items : [],
-    content: null,
-    isBooted: false,
-    isMenuActive: false,
-    lastItem: 20,
-    // As long as a value is defined, show it
-    // Otherwise, check if multiple
-    // to determine which default to provide
-    lazyValue: vm.value !== undefined
-      ? vm.value
-      : vm.multiple ? [] : undefined,
-    selectedIndex: -1,
-    selectedItems: [],
-    keyboardLookupPrefix: '',
-    keyboardLookupLastTime: 0
-  }),
 
   computed: {
     /* All items that the select has */

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -25,7 +25,7 @@ import useColorable from '../../composables/useColorable'
 import useLoadable, { loadableProps } from '../../composables/useLoadable'
 
 // Types
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 
 /* @vue/component */
 export default defineComponent({
@@ -89,20 +89,23 @@ export default defineComponent({
     const { setBackgroundColor, setTextColor } = useColorable(props)
     const { genProgress } = useLoadable(props, context)
 
+    const app = ref(null)
+    const isActive = ref(false)
+    const keyPressed = ref(0)
+    const lazyValue = ref(typeof props.value !== 'undefined' ? props.value : Number(props.min))
+    const oldValue = ref(null)
+
     return {
       setBackgroundColor,
       setTextColor,
-      genProgress
+      genProgress,
+      app,
+      isActive,
+      keyPressed,
+      lazyValue,
+      oldValue
     }
   },
-
-  data: vm => ({
-    app: {},
-    isActive: false,
-    keyPressed: 0,
-    lazyValue: typeof vm.value !== 'undefined' ? vm.value : Number(vm.min),
-    oldValue: null
-  }),
 
   computed: {
     classes () {


### PR DESCRIPTION
## Summary
- refactor VRating to manage interactive state inside setup and apply ripple via directives
- expose VSelect reactive state through setup for reuse while leaving computed/methods intact
- rebuild VSelectList with composition helpers and generate list content within setup
- move VSlider data fields to refs returned from setup

## Testing
- npm run lint *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c987a5998c8327894c1e3e3ec3b85d