### PR TITLE
Refine stepper, switch, and tabs composition logic

### DIFF
--- a/src/components/VSwitch/VSwitch.js
+++ b/src/components/VSwitch/VSwitch.js
@@ -47,7 +47,9 @@ export default defineComponent({
       'v-input--switch': true,
     }))
 
-    const switchData = computed(() => setTextColor(props.loading ? undefined : computedColor.value, {
+    const switchColor = computed(() => props.loading ? undefined : computedColor.value)
+
+    const switchData = computed(() => setTextColor(switchColor.value, {
       class: themeClasses.value,
     }))
 
@@ -66,21 +68,25 @@ export default defineComponent({
       ) onChange()
     }
 
+    const progressColor = computed(() => {
+      if (props.loading === true || props.loading === '') {
+        return props.color || 'primary'
+      }
+
+      return props.loading
+    })
+
     function genProgress () {
       if (props.loading === false) {
         return h(VFabTransition, {}, { default: () => [null] })
       }
-
-      const progressColor = (props.loading === true || props.loading === '')
-        ? (props.color || 'primary')
-        : props.loading
 
       const slotContent = slots.progress?.()
       const nodes = slotContent && slotContent.length
         ? slotContent
         : [h(VProgressCircular, {
           props: {
-            color: progressColor,
+            color: progressColor.value,
             size: 16,
             width: 2,
             indeterminate: true,
@@ -114,7 +120,7 @@ export default defineComponent({
 
     return () => h('div', {
       class: classes.value,
-      on: { keydown: onKeydown },
+      onKeydown,
     }, [
       genSwitch(),
       genLabel(),

--- a/src/components/VSystemBar/VSystemBar.ts
+++ b/src/components/VSystemBar/VSystemBar.ts
@@ -6,7 +6,7 @@ import useColorable, { colorProps } from '../../composables/useColorable'
 import useThemeable, { themeProps } from '../../composables/useThemeable'
 
 // Types
-import { defineComponent, h, computed, getCurrentInstance, watch } from 'vue'
+import { defineComponent, h, computed } from 'vue'
 
 export default defineComponent({
   name: 'v-system-bar',
@@ -37,17 +37,12 @@ export default defineComponent({
       return props.window ? 32 : 24
     })
 
-    const application = useApplicationable(props, computed(() => 'bar'), ['height', 'window'])
-    const vm = getCurrentInstance()
-
-    watch([application.app, application.applicationProperty, computedHeight], ([app]) => {
-      if (!app || !vm?.proxy) return
-      vm.proxy.$vuetify?.application.bind(
-        vm.uid,
-        application.applicationProperty.value,
-        computedHeight.value,
-      )
-    }, { immediate: true })
+    useApplicationable(
+      props,
+      computed(() => 'bar'),
+      ['height', 'window'],
+      { updateApplication: () => computedHeight.value },
+    )
 
     const classes = computed(() => ({
       'v-system-bar--lights-out': props.lightsOut,
@@ -58,12 +53,16 @@ export default defineComponent({
       ...themeClasses.value,
     }))
 
+    const barStyles = computed(() => ({
+      height: `${computedHeight.value}px`,
+    }))
+
     return () => h('div', setBackgroundColor(props.color, {
-      staticClass: 'v-system-bar',
-      class: classes.value,
-      style: {
-        height: `${computedHeight.value}px`,
+      class: {
+        'v-system-bar': true,
+        ...classes.value,
       },
+      style: barStyles.value,
     }), slots.default?.())
   },
 })

--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -25,7 +25,7 @@ export default defineComponent({
   setup (props, { attrs, slots, emit, expose }) {
     const { generateRouteLink } = useRoutable(props, { attrs, emit })
     const { groupClasses, toggle, isActive, activeClass } = useTabGroupable(props, emit)
-    useThemeable(props)
+    const { themeClasses } = useThemeable(props)
 
     const linkRef = ref()
     const vm = getCurrentInstance()
@@ -34,6 +34,7 @@ export default defineComponent({
       'v-tabs__item': true,
       'v-tabs__item--disabled': props.disabled,
       ...groupClasses.value,
+      ...themeClasses.value,
     }))
 
     const value = computed(() => {
@@ -86,7 +87,7 @@ export default defineComponent({
       const tag = props.disabled ? 'div' : link.tag
       data.ref = linkRef
 
-      return h('div', { staticClass: 'v-tabs__div' }, [h(tag, data, slots.default?.())])
+      return h('div', { class: 'v-tabs__div' }, [h(tag, data, slots.default?.())])
     }
   },
 })

--- a/src/components/VTabs/VTabItem.js
+++ b/src/components/VTabs/VTabItem.js
@@ -1,35 +1,58 @@
-// Extensions
+// Components
 import VWindowItem from '../VWindow/VWindowItem'
 
 // Utilities
 import { deprecate } from '../../util/console'
 
 // Types
-import { defineComponent, h, getCurrentInstance } from 'vue'
+import { defineComponent, h, mergeProps, getCurrentInstance } from 'vue'
+
+const windowItemProps = {
+  reverseTransition: {
+    type: [Boolean, String],
+    default: undefined,
+  },
+  transition: {
+    type: [Boolean, String],
+    default: undefined,
+  },
+  value: {
+    required: false,
+  },
+  lazy: Boolean,
+}
 
 export default defineComponent({
   name: 'v-tab-item',
-  extends: VWindowItem,
+
+  inheritAttrs: false,
 
   props: {
+    ...windowItemProps,
     id: String,
   },
 
-  setup (props) {
+  setup (props, { attrs, slots }) {
     const vm = getCurrentInstance()
 
     return () => {
-      const proxy = vm?.proxy ?? {}
-      const render = VWindowItem.options.render.call(proxy, h)
+      const forwardedAttrs = { ...attrs }
 
       if (props.id) {
-        deprecate('id', 'value', proxy)
-        render.data = render.data || {}
-        render.data.domProps = render.data.domProps || {}
-        render.data.domProps.id = props.id
+        deprecate('id', 'value', vm?.proxy)
+        forwardedAttrs.id = props.id
       }
 
-      return render
+      return h(
+        VWindowItem,
+        mergeProps({
+          reverseTransition: props.reverseTransition,
+          transition: props.transition,
+          value: props.value,
+          lazy: props.lazy,
+        }, forwardedAttrs),
+        slots,
+      )
     }
   },
 })


### PR DESCRIPTION
## Summary
- streamline VStepperStep by deriving color and icon state in computed helpers and using modern event bindings
- update VSwitch to reuse computed color helpers for loading state and keydown handling
- rework VSystemBar, VTab, and VTabItem to lean on composables for application registration, theming, and window item forwarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca7ed17e2c8327acdeedb22b69d9c3