### PR TITLE
refactor simple functional components to defineComponent

### DIFF
--- a/src/components/VBreadcrumbs/index.ts
+++ b/src/components/VBreadcrumbs/index.ts
@@ -1,8 +1,21 @@
+import { defineComponent, h } from 'vue'
+
 import VBreadcrumbs from './VBreadcrumbs'
 import VBreadcrumbsItem from './VBreadcrumbsItem'
-import { createSimpleFunctional } from '../../util/helpers'
 
-const VBreadcrumbsDivider = createSimpleFunctional('v-breadcrumbs__divider', 'li')
+const VBreadcrumbsDivider = defineComponent({
+  name: 'VBreadcrumbsDivider',
+
+  setup (_, { attrs, slots }) {
+    return () => {
+      const { class: className, ...restAttrs } = attrs as any
+      return h('li', {
+        ...restAttrs,
+        class: ['v-breadcrumbs__divider', className]
+      }, slots.default?.())
+    }
+  }
+})
 
 export { VBreadcrumbs, VBreadcrumbsItem, VBreadcrumbsDivider }
 

--- a/src/components/VCard/index.ts
+++ b/src/components/VCard/index.ts
@@ -1,10 +1,35 @@
-import { createSimpleFunctional } from '../../util/helpers'
+import { defineComponent, h } from 'vue'
 import VCard from './VCard'
 import VCardMedia from './VCardMedia'
 import VCardTitle from './VCardTitle'
 
-const VCardActions = createSimpleFunctional('v-card__actions')
-const VCardText = createSimpleFunctional('v-card__text')
+const VCardActions = defineComponent({
+  name: 'VCardActions',
+
+  setup (_, { attrs, slots }) {
+    return () => {
+      const { class: className, ...restAttrs } = attrs as any
+      return h('div', {
+        ...restAttrs,
+        class: ['v-card__actions', className]
+      }, slots.default?.())
+    }
+  }
+})
+
+const VCardText = defineComponent({
+  name: 'VCardText',
+
+  setup (_, { attrs, slots }) {
+    return () => {
+      const { class: className, ...restAttrs } = attrs as any
+      return h('div', {
+        ...restAttrs,
+        class: ['v-card__text', className]
+      }, slots.default?.())
+    }
+  }
+})
 
 export { VCard, VCardMedia, VCardTitle, VCardActions, VCardText }
 

--- a/src/components/VToolbar/index.ts
+++ b/src/components/VToolbar/index.ts
@@ -1,10 +1,35 @@
-import { createSimpleFunctional } from '../../util/helpers'
+import { defineComponent, h } from 'vue'
 
 import VToolbar from './VToolbar'
 import VToolbarSideIcon from './VToolbarSideIcon'
 
-const VToolbarTitle = createSimpleFunctional('v-toolbar__title')
-const VToolbarItems = createSimpleFunctional('v-toolbar__items')
+const VToolbarTitle = defineComponent({
+  name: 'VToolbarTitle',
+
+  setup (_, { attrs, slots }) {
+    return () => {
+      const { class: className, ...restAttrs } = attrs as any
+      return h('div', {
+        ...restAttrs,
+        class: ['v-toolbar__title', className]
+      }, slots.default?.())
+    }
+  }
+})
+
+const VToolbarItems = defineComponent({
+  name: 'VToolbarItems',
+
+  setup (_, { attrs, slots }) {
+    return () => {
+      const { class: className, ...restAttrs } = attrs as any
+      return h('div', {
+        ...restAttrs,
+        class: ['v-toolbar__items', className]
+      }, slots.default?.())
+    }
+  }
+})
 
 export { VToolbar, VToolbarSideIcon, VToolbarTitle, VToolbarItems }
 


### PR DESCRIPTION
## Summary
- rewrite VBreadcrumbsDivider as an inline defineComponent that renders an li element and forwards attributes and slots
- replace VCardActions and VCardText factory helpers with defineComponent wrappers while keeping existing exports
- refactor VToolbarTitle and VToolbarItems to use defineComponent so they forward data like the prior functional helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caa8c51e9483278b1697683d0f9f52