### PR TITLE
refactor: convert VList helpers to components

### DIFF
--- a/src/components/VGrid/index.js
+++ b/src/components/VGrid/index.js
@@ -1,12 +1,24 @@
-import {
-  createSimpleFunctional
-} from '../../util/helpers'
+import { defineComponent, h } from 'vue'
 import VContainer from './VContainer'
 import VContent from './VContent'
 import VFlex from './VFlex'
 import VLayout from './VLayout'
 
-const VSpacer = createSimpleFunctional('spacer', 'div', 'v-spacer')
+const VSpacer = defineComponent({
+  name: 'v-spacer',
+  inheritAttrs: false,
+  setup (_props, { attrs, slots }) {
+    return () => {
+      const { class: className, style, ...restAttrs } = attrs
+
+      return h('div', {
+        class: ['spacer', className],
+        style,
+        ...restAttrs
+      }, slots.default?.())
+    }
+  }
+})
 
 export {
   VContainer,

--- a/src/components/VList/index.ts
+++ b/src/components/VList/index.ts
@@ -1,4 +1,5 @@
-import { createSimpleFunctional } from '../../util/helpers'
+import { defineComponent, h } from 'vue'
+import type { SetupContext } from 'vue'
 
 import VList from './VList'
 import VListGroup from './VListGroup'
@@ -7,10 +8,36 @@ import VListTileAction from './VListTileAction'
 import VListTileAvatar from './VListTileAvatar'
 
 export { VList, VListGroup, VListTile, VListTileAction, VListTileAvatar }
-export const VListTileActionText = createSimpleFunctional('v-list__tile__action-text', 'span')
-export const VListTileContent = createSimpleFunctional('v-list__tile__content', 'div')
-export const VListTileTitle = createSimpleFunctional('v-list__tile__title', 'div')
-export const VListTileSubTitle = createSimpleFunctional('v-list__tile__sub-title', 'div')
+
+type Attrs = Record<string, unknown> & {
+  class?: unknown
+  style?: unknown
+}
+
+function createTileComponent (name: string, tag: string, baseClass: string) {
+  return defineComponent({
+    name,
+    inheritAttrs: false,
+    setup (_props: Record<string, never>, context: SetupContext) {
+      const { attrs, slots } = context
+
+      return () => {
+        const { class: className, style, ...restAttrs } = attrs as Attrs
+
+        return h(tag, {
+          class: [baseClass, className],
+          style: style as any,
+          ...restAttrs
+        }, slots.default?.())
+      }
+    }
+  })
+}
+
+export const VListTileActionText = createTileComponent('v-list-tile-action-text', 'span', 'v-list__tile__action-text')
+export const VListTileContent = createTileComponent('v-list-tile-content', 'div', 'v-list__tile__content')
+export const VListTileTitle = createTileComponent('v-list-tile-title', 'div', 'v-list__tile__title')
+export const VListTileSubTitle = createTileComponent('v-list-tile-sub-title', 'div', 'v-list__tile__sub-title')
 
 export default {
   $_vuetify_subcomponents: {


### PR DESCRIPTION
## Summary
- replace VList tile helper exports with defineComponent renderers that merge incoming attrs and slots
- convert VSpacer to a defineComponent-based render function and remove usage of createSimpleFunctional

## Testing
- npx tsc --noEmit *(fails: repository still contains numerous pre-existing type errors such as missing Vue type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68cab2bf11a08327b4445f5b83dca4ab