### PR TITLE
refactor: update v-tabs-items to composition api

### DIFF
--- a/src/components/VTabs/VTabsItems.js
+++ b/src/components/VTabs/VTabsItems.js
@@ -1,65 +1,90 @@
 // Extensions
 import VWindow from '../VWindow/VWindow'
 
-/* @vue/component */
-export default VWindow.extend({
-  name: 'v-tabs-items',
+// Vue
+import { defineComponent, computed, getCurrentInstance, inject, onBeforeUnmount, onMounted, watch } from 'vue'
 
-  inject: {
-    registerItems: {
-      default: null
-    },
-    tabProxy: {
-      default: null
-    },
-    unregisterItems: {
-      default: null
-    }
-  },
+const baseSetup = VWindow.setup
+
+export default defineComponent({
+  name: 'v-tabs-items',
+  extends: VWindow,
 
   props: {
     cycle: Boolean
   },
 
-  watch: {
-    internalValue (val) {
-      /* istanbul ignore else */
-      if (this.tabProxy) this.tabProxy(val)
-    }
-  },
+  setup (props, ctx) {
+    const render = typeof baseSetup === 'function' ? baseSetup(props, ctx) : undefined
+    const { expose } = ctx
+    const vm = getCurrentInstance()
+    const proxy = vm && vm.proxy
 
-  created () {
-    this.registerItems && this.registerItems(this.changeModel)
-  },
+    const registerItems = inject('registerItems', null)
+    const tabProxy = inject('tabProxy', null)
+    const unregisterItems = inject('unregisterItems', null)
 
-  beforeDestroy () {
-    this.unregisterItems && this.unregisterItems()
-  },
-
-  methods: {
-    changeModel (val) {
-      this.internalValue = val
-    },
-    // For backwards compatability with v1.2
-    getValue (item, i) {
-      /* istanbul ignore if */
-      if (item.id) return item.id
-
-      return VWindow.options.methods.getValue.call(this, item, i)
-    },
-    next () {
-      if (!this.cycle && this.internalIndex === this.items.length - 1) {
-        return
+    const internalValue = computed({
+      get: () => proxy ? proxy.internalValue : undefined,
+      set: val => {
+        if (proxy) proxy.internalValue = val
       }
+    })
+    const internalIndex = computed(() => proxy && typeof proxy.internalIndex === 'number' ? proxy.internalIndex : -1)
+    const items = computed(() => proxy && Array.isArray(proxy.items) ? proxy.items : [])
 
-      VWindow.options.methods.next.call(this)
-    },
-    prev () {
-      if (!this.cycle && this.internalIndex === 0) {
-        return
-      }
-
-      VWindow.options.methods.prev.call(this)
+    function changeModel (val) {
+      internalValue.value = val
     }
+
+    function getValue (item, i) {
+      if (item && item.id) return item.id
+
+      return proxy ? VWindow.options.methods.getValue.call(proxy, item, i) : undefined
+    }
+
+    function next () {
+      if (!proxy) return
+      if (!props.cycle && internalIndex.value === items.value.length - 1) return
+
+      VWindow.options.methods.next.call(proxy)
+    }
+
+    function prev () {
+      if (!proxy) return
+      if (!props.cycle && internalIndex.value === 0) return
+
+      VWindow.options.methods.prev.call(proxy)
+    }
+
+    watch(() => internalValue.value, val => {
+      if (tabProxy) tabProxy(val)
+    })
+
+    onMounted(() => {
+      if (registerItems) registerItems(changeModel)
+    })
+
+    onBeforeUnmount(() => {
+      if (unregisterItems) unregisterItems()
+    })
+
+    if (proxy) {
+      Object.assign(proxy, {
+        changeModel,
+        getValue,
+        next,
+        prev
+      })
+    }
+
+    expose({
+      changeModel,
+      getValue,
+      next,
+      prev
+    })
+
+    return render
   }
 })


### PR DESCRIPTION
## Summary
- refactor `VTabsItems` to use `defineComponent` with the Composition API while extending `VWindow`
- wire injected tab registration callbacks through the Composition API lifecycle and expose navigation helpers
- preserve VWindow behaviors by delegating rendering and calling the base window methods for navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cac305b45c8327bd7256dee55dbf05