### PR TITLE
Refactor VTextField computed state into setup

### DIFF
--- a/src/components/VTextarea/VTextarea.js
+++ b/src/components/VTextarea/VTextarea.js
@@ -36,8 +36,6 @@ export default defineComponent({
 
     const vm = getCurrentInstance()
     const proxy = vm?.proxy
-    const baseComponent = vm?.type?.extends
-    const baseComputed = baseComponent?.options?.computed || {}
 
     const inputHeight = ref('auto')
 
@@ -47,15 +45,9 @@ export default defineComponent({
 
     const noResizeHandle = computed(() => props.noResize || props.autoGrow)
 
-    const baseClasses = computed(() => {
-      const getter = baseComputed.classes
-      return getter && proxy ? getter.call(proxy) : {}
-    })
+    const baseClasses = computed(() => proxy?.classes || {})
 
-    const baseIsEnclosed = computed(() => {
-      const getter = baseComputed.isEnclosed
-      return getter && proxy ? getter.call(proxy) : false
-    })
+    const baseIsEnclosed = computed(() => proxy?.isEnclosed ?? false)
 
     const classes = computed(() => ({
       ...baseClasses.value,


### PR DESCRIPTION
## Summary
- create Composition API refs for legacy data members in VTextField
- rebuild the text field computed state in setup and expose it for render helpers
- adapt VTextarea to consume the proxied VTextField state after the refactor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cac958336c8327ad75227605ad0f5f