### PR TITLE
Expose text field handlers via expose

### DIFF
--- a/src/components/VTextarea/VTextarea.js
+++ b/src/components/VTextarea/VTextarea.js
@@ -39,9 +39,7 @@ export default defineComponent({
 
     const inputHeight = ref('auto')
 
-    const textField = useTextFieldController()
-    const baseGenInput = textField.base?.genInput
-    const baseOnInput = textField.base?.onInput
+    const { genInput: textFieldGenInput, onInput: textFieldOnInput } = useTextFieldController()
 
     const noResizeHandle = computed(() => props.noResize || props.autoGrow)
 
@@ -74,9 +72,9 @@ export default defineComponent({
     }
 
     function genInput () {
-      if (!baseGenInput) return null
+      if (!textFieldGenInput) return null
 
-      const input = baseGenInput()
+      const input = textFieldGenInput()
       if (!input || !input.data) return input
 
       input.tag = 'textarea'
@@ -91,7 +89,7 @@ export default defineComponent({
     }
 
     function onInput (e) {
-      baseOnInput && baseOnInput(e)
+      textFieldOnInput && textFieldOnInput(e)
       if (props.autoGrow) calculateInputHeight()
     }
 


### PR DESCRIPTION
## Summary
- expose VTextField focus/blur/input helpers through the setup context so refs can access them
- refactor useTextFieldController to read the exposed handlers and provide fallbacks
- update VTextarea to consume the new controller helpers when customizing the textarea input

## Testing
- not run (legacy workspace)

------
https://chatgpt.com/codex/tasks/task_e_68cad7219e208327b16609d4bedb6c73