### PR TITLE
fix: export useSliderController from VSlider index

### DIFF
--- a/src/components/VSlider/index.js
+++ b/src/components/VSlider/index.js
@@ -1,4 +1,4 @@
-import VSlider from './VSlider'
+import VSlider, { useSliderController } from './VSlider'
 
-export { VSlider }
+export { VSlider, useSliderController }
 export default VSlider


### PR DESCRIPTION
## Summary
- re-export `useSliderController` alongside `VSlider` so range slider imports succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cae7164f94832787dce65cc43bdb7e