### PR TITLE
Specify named exports for library build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
     rollupOptions: {
       external: ['vue'],
       output: {
+        exports: 'named',
         globals: {
           vue: 'Vue'
         }


### PR DESCRIPTION
## Summary
- configure the library build to emit named exports in Rollup output to avoid mixed default/named export warnings
- declare the package as ESM so Vite no longer triggers the deprecated CJS Node API warning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae7adc57483279e15f3ae8ee231b6