### PR TITLE
Fix lib.d.ts import paths

### DIFF
--- a/src/types/colors.d.ts
+++ b/src/types/colors.d.ts
@@ -105,3 +105,5 @@ declare module 'vuetify/lib/util/colors' {
   const colors: Colors
   export default colors
 }
+
+export type Colors = import('vuetify/lib/util/colors').Colors

--- a/src/types/lib.d.ts
+++ b/src/types/lib.d.ts
@@ -1,7 +1,7 @@
 declare module 'vuetify/lib' {
   import { Component, DirectiveOptions } from 'vue'
-  import { Vuetify } from 'vuetify'
-  import { Colors } from 'vuetify/lib/util/colors'
+  import type { Vuetify } from './index'
+  import type { Colors } from './colors'
 
   const Vuetify: Vuetify
   const colors: Colors


### PR DESCRIPTION
## Summary
- correct the Vuetify type import in `lib.d.ts` to reference the local type definition file
- re-export the `Colors` type so `lib.d.ts` can consume it through a relative import

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caec690dd08327be70171ee87e14b4