### PR TITLE
Fix TypeScript imports for Vuetify typings

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,23 +1,17 @@
 /* eslint-disable max-len */
 
-import {
-  VueConstructor,
-  ComponentOptions,
-  FunctionalComponentOptions,
-  VNodeData
-} from 'vue'
-import { CombinedVueInstance, Vue } from 'vue/types/vue'
-import {
-  RecordPropsDefinition,
-  ThisTypedComponentOptionsWithArrayProps,
-  ThisTypedComponentOptionsWithRecordProps
-} from 'vue/types/options'
-import { TouchStoredHandlers } from './directives/touch'
+export type Dictionary<T> = Record<string, T>
+
+export interface TouchStoredHandlers {
+  [event: string]: EventListenerOrEventListenerObject
+}
 
 declare global {
   interface Window {
-    Vue: VueConstructor
+    Vue?: import('vue').App<Element>
   }
+
+  type Dictionary<T> = Record<string, T>
 
   interface HTMLCollection {
     [Symbol.iterator] (): IterableIterator<Element>
@@ -57,68 +51,6 @@ declare global {
   function parseInt(s: string | number, radix?: number): number
   function parseFloat(string: string | number): number
 
-  export type Dictionary<T> = Record<string, T>
-
-  export const __VUETIFY_VERSION__: string
-  export const __REQUIRED_VUE__: string
-}
-
-declare module 'vue/types/vnode' {
-  export interface VNodeData {
-    model?: {
-      callback: (v: any) => void
-      expression: string
-      value: any
-    }
-  }
-}
-
-declare module 'vue/types/vue' {
-  export type OptionsVue<Instance extends Vue, Data, Methods, Computed, Props, Options = {}> = VueConstructor<
-    CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue,
-    Options
-  >
-
-  export interface Vue {
-    _uid: number
-    _isDestroyed: boolean
-
-    /** bindObjectProps */
-    _b (data: VNodeData, tag: string, value: Dictionary<any> | Dictionary<any>[], asProp?: boolean, isSync?: boolean): VNodeData
-
-    /** bindObjectListeners */
-     _g (data: VNodeData, value: {}): VNodeData
-  }
-
-  export interface RawComponentOptions<
-    V extends Vue = Vue,
-    Data = {} | undefined,
-    Methods = {} | undefined,
-    Computed = {} | undefined,
-    Props = {} | undefined
-  > {
-    name?: string
-    data: Data
-    methods: Methods
-    computed: {
-      [C in keyof Computed]: (this: V) => Computed[C]
-    }
-    props: Props
-  }
-
-  interface VueConstructor<
-    V extends Vue = Vue,
-    Options = Record<string, any>
-  > {
-    version: string
-    /* eslint-disable-next-line camelcase */
-    $_vuetify_subcomponents?: Record<string, VueConstructor>
-    options: Options
-
-    extend<Data, Methods, Computed, Options, PropNames extends string = never> (options?: ThisTypedComponentOptionsWithArrayProps<V, Data, Methods, Computed, PropNames> & Options): OptionsVue<V, Data, Methods, Computed, Record<PropNames, any>, Options>
-    extend<Data, Methods, Computed, Props, Options> (options?: ThisTypedComponentOptionsWithRecordProps<V, Data, Methods, Computed, Props> & Options): OptionsVue<V, Data, Methods, Computed, Props, Options>
-    extend<Options, PropNames extends string = never> (definition: FunctionalComponentOptions<Record<PropNames, any>, PropNames[]> & Options): OptionsVue<V, {}, {}, {}, Record<PropNames, any>, Options>
-    extend<Props, Options> (definition: FunctionalComponentOptions<Props, RecordPropsDefinition<Props>> & Options): OptionsVue<V, {}, {}, {}, Props, Options>
-    extend<V extends Vue = Vue> (options?: ComponentOptions<V> & Options): OptionsVue<V, {}, {}, {}, {}, Options>
-  }
+  const __VUETIFY_VERSION__: string
+  const __REQUIRED_VUE__: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@ import "@/css/vuetify.css"
 import VuetifyComponent from './components/Vuetify'
 import * as components from './components'
 import directives from './directives'
-import { VueConstructor } from 'vue'
+import type { App, Plugin } from 'vue'
 import { Vuetify as VuetifyPlugin, VuetifyUseOptions } from './types'
 
 const Vuetify: VuetifyPlugin = {
-  install (Vue: VueConstructor, args?: VuetifyUseOptions): void {
-    Vue.use(VuetifyComponent, {
+  install (app: App, args?: VuetifyUseOptions): void {
+    app.use(VuetifyComponent as unknown as Plugin, {
       components,
       directives,
       ...args
@@ -16,8 +16,8 @@ const Vuetify: VuetifyPlugin = {
   version: __VUETIFY_VERSION__
 }
 
-if (typeof window !== 'undefined' && window.Vue) {
-  window.Vue.use(Vuetify)
+if (typeof window !== 'undefined' && window.Vue?.use) {
+  window.Vue.use(Vuetify as unknown as Plugin)
 }
 
 export default Vuetify

--- a/src/types/alacarte.d.ts
+++ b/src/types/alacarte.d.ts
@@ -1,30 +1,24 @@
 declare module 'vuetify/es5/components/Vuetify' {
-  import type { Vuetify } from 'vuetify'
-
-  const VuetifyPlugin: Vuetify
+  const VuetifyPlugin: import('vuetify').Vuetify
 
   export default VuetifyPlugin
 }
 
 declare module 'vuetify/es5/components/*' {
-  import type { ComponentOrPack } from 'vuetify'
-
   const VuetifyComponent: {
-    default: ComponentOrPack
-    [key: string]: ComponentOrPack
+    default: import('vuetify').ComponentOrPack
+    [key: string]: import('vuetify').ComponentOrPack
   }
 
   export = VuetifyComponent
 }
 
 declare module 'vuetify/es5/directives' {
-  import type { ObjectDirective } from 'vue'
-
-  const ClickOutside: ObjectDirective
-  const Ripple: ObjectDirective
-  const Resize: ObjectDirective
-  const Scroll: ObjectDirective
-  const Touch: ObjectDirective
+  const ClickOutside: import('vue').ObjectDirective
+  const Ripple: import('vue').ObjectDirective
+  const Resize: import('vue').ObjectDirective
+  const Scroll: import('vue').ObjectDirective
+  const Touch: import('vue').ObjectDirective
 
   export {
     ClickOutside,

--- a/src/types/lib.d.ts
+++ b/src/types/lib.d.ts
@@ -1,7 +1,8 @@
 declare module 'vuetify/lib' {
-  import type { Component, ObjectDirective } from 'vue'
-  import type { Vuetify } from './index'
-  import type { Colors } from './colors'
+  type Component = import('vue').Component
+  type ObjectDirective = import('vue').ObjectDirective
+  type Vuetify = import('vuetify').Vuetify
+  type Colors = import('vuetify/lib/util/colors').Colors
 
   const Vuetify: Vuetify
   const colors: Colors

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,9 +42,13 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {                             /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // },
+    "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {                             /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "@/*": ["src/*"],
+      "@/css/*": ["css/*"],
+      "vuetify": ["src/index.ts"],
+      "vuetify/*": ["src/*"]
+    },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
## Summary
- add TypeScript path mappings for Vuetify and existing aliases so the compiler can resolve package-style imports
- update Vuetify declaration files to reference types through non-relative `import()` expressions and Vue 3 primitives
- simplify the global typings and entry install routine to use Vue 3 `App` instances while keeping browser auto-install support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf06e06e08327bae476e7e4921dba