### PR TITLE
fix: align type definition import paths with project structure

### DIFF
--- a/src/types/alacarte.d.ts
+++ b/src/types/alacarte.d.ts
@@ -1,10 +1,10 @@
-declare module 'vuetify/es5/components/Vuetify' {
+declare module 'vuetify/components/Vuetify' {
   const VuetifyPlugin: import('vuetify').Vuetify
 
   export default VuetifyPlugin
 }
 
-declare module 'vuetify/es5/components/*' {
+declare module 'vuetify/components/*' {
   const VuetifyComponent: {
     default: import('vuetify').ComponentOrPack
     [key: string]: import('vuetify').ComponentOrPack
@@ -13,7 +13,7 @@ declare module 'vuetify/es5/components/*' {
   export = VuetifyComponent
 }
 
-declare module 'vuetify/es5/directives' {
+declare module 'vuetify/directives' {
   const ClickOutside: import('vue').ObjectDirective
   const Ripple: import('vue').ObjectDirective
   const Resize: import('vue').ObjectDirective

--- a/src/types/colors.d.ts
+++ b/src/types/colors.d.ts
@@ -1,4 +1,4 @@
-declare module 'vuetify/es5/util/colors' {
+declare module 'vuetify/util/colors' {
   interface BaseColor {
     readonly base: string
     readonly lighten5: string
@@ -53,57 +53,9 @@ declare module 'vuetify/es5/util/colors' {
 }
 
 declare module 'vuetify/lib/util/colors' {
-  interface BaseColor {
-    readonly base: string
-    readonly lighten5: string
-    readonly lighten4: string
-    readonly lighten3: string
-    readonly lighten2: string
-    readonly lighten1: string
-    readonly darken1: string
-    readonly darken2: string
-    readonly darken3: string
-    readonly darken4: string
-  }
-
-  interface Color extends BaseColor {
-    readonly accent1: string
-    readonly accent2: string
-    readonly accent3: string
-    readonly accent4: string
-  }
-
-  interface Shade {
-    readonly black: string
-    readonly white: string
-    readonly transparent: string
-  }
-
-  export interface Colors {
-    red: Color
-    pink: Color
-    purple: Color
-    deepPurple: Color
-    indigo: Color
-    blue: Color
-    lightBlue: Color
-    cyan: Color
-    teal: Color
-    green: Color
-    lightGreen: Color
-    lime: Color
-    yellow: Color
-    amber: Color
-    orange: Color
-    deepOrange: Color
-    brown: BaseColor
-    blueGrey: BaseColor
-    grey: BaseColor
-    shades: Shade
-  }
-
-  const colors: Colors
+  export { Colors } from 'vuetify/util/colors'
+  const colors: import('vuetify/util/colors').Colors
   export default colors
 }
 
-export type Colors = import('vuetify/lib/util/colors').Colors
+export type Colors = import('vuetify/util/colors').Colors

--- a/src/types/lib.d.ts
+++ b/src/types/lib.d.ts
@@ -2,7 +2,7 @@ declare module 'vuetify/lib' {
   type Component = import('vue').Component
   type ObjectDirective = import('vue').ObjectDirective
   type Vuetify = import('vuetify').Vuetify
-  type Colors = import('vuetify/lib/util/colors').Colors
+  type Colors = import('vuetify/util/colors').Colors
 
   const Vuetify: Vuetify
   const colors: Colors


### PR DESCRIPTION
## Summary
- update module declarations in the type definitions to reference the Vue 3 port's component, directive, and utility locations
- provide an alias module for colors that matches the new path while still exporting the same typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf446dfd083279b5af853e2d1b863