### PR TITLE
Fix Vuetify type exports for alacarte definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,4 @@ if (typeof window !== 'undefined' && window.Vue?.use) {
 }
 
 export default Vuetify
+export type { ComponentOrPack, Vuetify, VuetifyUseOptions } from './types'


### PR DESCRIPTION
## Summary
- re-export Vuetify's key type definitions from the library entry point so declaration files can reference them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd1c05420832798b89c45d343c579