### PR TITLE
Fix Vuetify plugin registration for Vue 3

### DIFF
--- a/src/components/Vuetify/goTo/index.ts
+++ b/src/components/Vuetify/goTo/index.ts
@@ -3,15 +3,22 @@ import {
   getContainer,
   getOffset
 } from './util'
-import Vue from 'vue'
+import type { ComponentPublicInstance } from 'vue'
+import type { VuetifyApplication } from '../../../types'
 
-type GoToTarget = number | string | HTMLElement | Vue
+type GoToTarget = number | string | HTMLElement | ComponentPublicInstance
 interface GoToSettings {
-  container: string | HTMLElement | Vue
+  container: string | HTMLElement | ComponentPublicInstance
   duration: number
   offset: number
   easing: string | easingPatterns.EasingFunction
   appOffset: boolean
+}
+
+let application: VuetifyApplication | undefined
+
+export function setGoToApplication (app: VuetifyApplication): void {
+  application = app
 }
 
 export default function goTo (_target: GoToTarget, _settings: Partial<GoToSettings> = {}): Promise<number> {
@@ -25,12 +32,14 @@ export default function goTo (_target: GoToTarget, _settings: Partial<GoToSettin
   }
   const container = getContainer(settings.container)
 
-  if (settings.appOffset) {
+  const currentApplication = application
+
+  if (settings.appOffset && currentApplication) {
     const isDrawer = container.classList.contains('v-navigation-drawer')
     const isClipped = container.classList.contains('v-navigation-drawer--clipped')
 
-    settings.offset += Vue.prototype.$vuetify.application.bar
-    if (!isDrawer || isClipped) settings.offset += Vue.prototype.$vuetify.application.top
+    settings.offset += currentApplication.bar
+    if (!isDrawer || isClipped) settings.offset += currentApplication.top
   }
 
   const startTime = performance.now()

--- a/src/components/Vuetify/goTo/util.ts
+++ b/src/components/Vuetify/goTo/util.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 
 // Return target's cumulative offset from the top
 export function getOffset (target: any): number {
@@ -39,11 +39,15 @@ function type (el: any) {
 function $ (el: any): HTMLElement | null {
   if (typeof el === 'string') {
     return document.querySelector<HTMLElement>(el)
-  } else if (el && el._isVue) {
-    return (el as Vue).$el as HTMLElement
+  } else if (isComponentInstance(el)) {
+    return (el as ComponentPublicInstance).$el as HTMLElement
   } else if (el instanceof HTMLElement) {
     return el
   } else {
     return null
   }
+}
+
+function isComponentInstance (value: any): value is ComponentPublicInstance {
+  return Boolean(value && typeof value === 'object' && '$el' in value)
 }


### PR DESCRIPTION
## Summary
- refactor the Vuetify install plugin to use the Vue 3 app API and register components globally
- wire goTo helpers to the framework application data instead of Vue.prototype accessors
- update goTo utilities to work with Vue 3 component public instances

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cbf52837808327b4ffdcab1d02ccba