### PR TITLE
Fix menu props access for Vue 3 components

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -11,6 +11,8 @@ import { keyCodes } from '../../util/helpers'
 // Types
 import { defineComponent, ref, computed, watch } from 'vue'
 
+const menuPropsType = VSelect.options?.props?.menuProps?.type ?? VSelect.props?.menuProps?.type ?? [String, Array, Object]
+
 const defaultMenuProps = {
   ...VSelectMenuProps,
   offsetY: true,
@@ -43,7 +45,7 @@ export default defineComponent({
       default: undefined
     },
     menuProps: {
-      type: VSelect.options.props.menuProps.type,
+      type: menuPropsType,
       default: () => defaultMenuProps
     },
     autoSelectFirst: {

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -432,7 +432,8 @@ export default defineComponent({
     function genMenu () {
       const propsData = { ...menuProps.value, activator: proxy?.$refs?.['input-slot'] }
 
-      const inheritedProps = Object.keys(VMenu.options.props)
+      const menuPropDefinitions = VMenu.options?.props ?? VMenu.props ?? {}
+      const inheritedProps = Object.keys(menuPropDefinitions)
 
       const deprecatedProps = Object.keys(attrs).reduce((acc, attr) => {
         if (inheritedProps.includes(camelize(attr))) acc.push(attr)
@@ -453,7 +454,7 @@ export default defineComponent({
         const separator = multiple ? '\n' : '\''
 
         const onlyBools = Object.keys(replacement).every(prop => {
-          const propType = VMenu.options.props[prop]
+          const propType = menuPropDefinitions[prop]
           const value = replacement[prop]
           return value === true || ((propType.type || propType) === Boolean && value === '')
         })


### PR DESCRIPTION
## Summary
- update `v-select` to read `v-menu` prop definitions without relying on Vue 2's `options` bag
- reuse the resolved `menuProps` type in `v-autocomplete` so it no longer accesses `VSelect.options`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cc0816ce288327b5d758281ce1393b