### PR TITLE
Define __REQUIRED_VUE__ constant for Vite builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,7 +53,8 @@ export default defineConfig({
     ]
   },
   define: {
-    __VUETIFY_VERSION__: JSON.stringify(process.env.npm_package_version)
+    __VUETIFY_VERSION__: JSON.stringify(process.env.npm_package_version),
+    __REQUIRED_VUE__: JSON.stringify(process.env.npm_package_dependencies_vue || '^3.0.0')
   },
   build: {
     lib: {


### PR DESCRIPTION
## Summary
- ensure Vite defines the __REQUIRED_VUE__ global
- fall back to a sensible default if the package metadata is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc0b3c892c8327917f392428582eff