### PR TITLE
Fix CommonJS plugin install by adjusting build outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "vuetify-1-vue3",
   "version": "0.0.1",
   "type": "module",
-  "main": "dist/vuetify.umd.js",
+  "main": "dist/vuetify.cjs",
   "module": "dist/vuetify.es.js",
   "exports": {
     ".": {
       "import": "./dist/vuetify.es.js",
-      "require": "./dist/vuetify.umd.js"
+      "require": "./dist/vuetify.cjs"
     },
     "./css": "./css/vuetify.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ function vuetifyCjsExportPlugin (): Plugin {
       const chunk = bundle['vuetify.cjs']
 
       if (chunk && chunk.type === 'chunk') {
-        chunk.code += '\nmodule.exports = exports.default;\nObject.assign(module.exports, exports);\n'
+        chunk.code += '\nconst __cjsExports = exports;\nconst __defaultExport = __cjsExports && __cjsExports.default;\nif (__defaultExport) {\n  module.exports = __defaultExport;\n  Object.defineProperty(module.exports, "__esModule", { value: true });\n  module.exports.default = __defaultExport;\n  const __descriptors = Object.getOwnPropertyDescriptors(__cjsExports);\n  const __names = Object.getOwnPropertyNames(__descriptors);\n  const __symbols = typeof Object.getOwnPropertySymbols === "function" ? Object.getOwnPropertySymbols(__descriptors) : [];\n  for (const __key of __names.concat(__symbols)) {\n    if (__key === "default") continue;\n    Object.defineProperty(module.exports, __key, __descriptors[__key]);\n  }\n}\n'
       }
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,11 +34,25 @@ function vuetifyCssPlugin (): Plugin {
   }
 }
 
+function vuetifyCjsExportPlugin (): Plugin {
+  return {
+    name: 'vuetify-cjs-export',
+    generateBundle (_, bundle) {
+      const chunk = bundle['vuetify.cjs']
+
+      if (chunk && chunk.type === 'chunk') {
+        chunk.code += '\nmodule.exports = exports.default;\nObject.assign(module.exports, exports);\n'
+      }
+    }
+  }
+}
+
 export default defineConfig({
   plugins: [
     vue(),
     vueJsx(),
-    vuetifyCssPlugin()
+    vuetifyCssPlugin(),
+    vuetifyCjsExportPlugin()
   ],
   resolve: {
     alias: [
@@ -60,8 +74,18 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/entry-lib.ts'),
       name: 'Vuetify',
-      fileName: (format) => `vuetify.${format}.js`,
-        formats: ['es', 'umd']
+      fileName: (format) => {
+        if (format === 'cjs') {
+          return 'vuetify.cjs'
+        }
+
+        if (format === 'umd') {
+          return 'vuetify.umd.js'
+        }
+
+        return `vuetify.${format}.js`
+      },
+      formats: ['es', 'umd', 'cjs']
     },
     rollupOptions: {
       external: ['vue'],


### PR DESCRIPTION
## Summary
- add a post-build tweak so the CommonJS bundle exposes the plugin directly via `module.exports`
- emit a dedicated `vuetify.cjs` build artifact and point the package `require` entry at it

## Testing
- `npm run build`
- `npm run typecheck` *(fails: vue-tsc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2526a6008327b0588d106fa50bcb